### PR TITLE
Closing issue #30 by exporting home in process

### DIFF
--- a/modules/local/isoquant.nf
+++ b/modules/local/isoquant.nf
@@ -7,6 +7,9 @@ process ISOQUANT {
         'https://depot.galaxyproject.org/singularity/isoquant:3.5.0--hdfd78af_0' :
         'biocontainers/isoquant:3.5.0--hdfd78af_0' }"
 
+    // setting custom home mount (see issue #30)
+    containerOptions "--bind ${task.workDir}:/home"
+
     input:
     tuple val(meta), path(bam), path(bai)
     tuple val(meta_gtf), path(gtf)

--- a/modules/local/isoquant.nf
+++ b/modules/local/isoquant.nf
@@ -7,9 +7,6 @@ process ISOQUANT {
         'https://depot.galaxyproject.org/singularity/isoquant:3.5.0--hdfd78af_0' :
         'biocontainers/isoquant:3.5.0--hdfd78af_0' }"
 
-    // setting custom home mount (see issue #30)
-    containerOptions "--bind ${task.workDir}:/home"
-
     input:
     tuple val(meta), path(bam), path(bai)
     tuple val(meta_gtf), path(gtf)
@@ -29,8 +26,11 @@ process ISOQUANT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
+    // setting custom home via export (see issue #30)
     if ( !group_category?.trim() ){
         """
+        export HOME=\$(pwd)
+
         isoquant.py ${args} \\
                     --threads $task.cpus \\
                     --datatype nanopore \\
@@ -49,6 +49,8 @@ process ISOQUANT {
         """
     } else {
         """
+        export HOME=\$(pwd)
+
         isoquant.py ${args} \\
                     --threads $task.cpus \\
                     --data_type nanopore \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -146,10 +146,10 @@ profiles {
         shifter.enabled         = false
         charliecloud.enabled    = false
         apptainer.enabled       = false
-        docker.runOptions       = '-u $(id -u):$(id -g) -e HOME=$(pwd)'
+        docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64 -e HOME=$(pwd)'
+        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
     singularity {
         singularity.enabled     = true


### PR DESCRIPTION
This PR closes issue #30 by simplifying usage of the pipeline without the need set `export NXF_SINGULARITY_HOME_MOUNT=true` for users using Singularity, and without having to set a warning in the documentation.