### PR TITLE
Handle missing corrected_bc column in barcode info parsing

### DIFF
--- a/bin/tag_barcodes.py
+++ b/bin/tag_barcodes.py
@@ -130,15 +130,16 @@ def read_bc_info(bc_info):
 
     with open(bc_info) as fh_bc_info:
         for entry in fh_bc_info:
-            # Sequence names can contain other information and this other
-            #   information can use the underscore as a delimiter
-            entry = entry.strip('\n')
-            read_id, bc, bc_info, umi, umi_qual, corrected_bc = entry.split('\t')
-
-            if corrected_bc:
-                bc_info_dict[read_id] = UmiBcRead(
-                    read_id, bc, bc_info, umi, umi_qual, corrected_bc
-                )
+            entry = entry.strip("\n")
+            fields = entry.split("\t")
+            # Ensure at least five columns exist
+            if len(fields) < 5:
+                continue  # Skip malformed rows
+            read_id, bc, bc_info, umi, umi_qual = fields[:5]
+            corrected_bc = fields[5] if len(fields) > 5 else None  # Handle missing column
+            bc_info_dict[read_id] = UmiBcRead(
+            read_id, bc, bc_info, umi, umi_qual, corrected_bc
+        )
 
     return bc_info_dict
 


### PR DESCRIPTION
<!--
# nf-core/scnanoseq pull request

Many thanks for contributing to nf-core/scnanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)
-->

## Description of Changes

This PR updates the barcode info parsing logic in the pipeline to support input lines that may be missing the `corrected_bc` (6th column) field.
Previously, such lines were silently skipped. Now, they are parsed and included in the output, with corrected_bc set to None when missing.

### Why

Some datasets do not include the `corrected_bc` column, but we still want to process those reads.
This change improves robustness and flexibility in handling variable input formats.

---

## PR checklist

* [x] This comment contains a description of changes (with reason).
* [ ] If you've fixed a bug or added code that should be tested, add tests!
* [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)?
* [ ] If necessary, also make a PR on the `nf-core/test-datasets` repository.
* [ ] Make sure your code lints (`nf-core pipelines lint`).
* [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
* [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
* [ ] Usage Documentation in `docs/usage.md` is updated.
* [ ] Output Documentation in `docs/output.md` is updated.
* [ ] `CHANGELOG.md` is updated.
* [ ] `README.md` is updated (including new tool citations and authors/contributors).
