### PR TITLE
Module update: nanocomp

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -48,7 +48,7 @@
                     },
                     "nanocomp": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "f0c766af7e897ecf52c13f5424426f06d221194b",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/nanocomp/nanocomp.diff"
                     },

--- a/modules/nf-core/nanocomp/environment.yml
+++ b/modules/nf-core/nanocomp/environment.yml
@@ -1,7 +1,7 @@
-name: nanocomp
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - bioconda:nanocomp=1.21.0
+  - nanocomp=1.21.0

--- a/modules/nf-core/nanocomp/main.nf
+++ b/modules/nf-core/nanocomp/main.nf
@@ -115,7 +115,6 @@ process NANOCOMP {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch versions.yml
     touch "${prefix}"NanoComp_lengths_violin.html
     touch "${prefix}"NanoComp_log_length_violin.html
     touch "${prefix}"NanoComp_N50.html
@@ -134,5 +133,10 @@ process NANOCOMP {
     touch "${prefix}"NanoComp_CumulativeYieldPlot_Gigabases.html
     touch "${prefix}"NanoComp_sequencing_speed_over_time.html
     touch "${prefix}"NanoStats.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        nanocomp: \$(echo \$(NanoComp --version 2>&1) | sed 's/^.*NanoComp //; s/Using.*\$//' ))
+    END_VERSIONS
     """
 }

--- a/modules/nf-core/nanocomp/meta.yml
+++ b/modules/nf-core/nanocomp/meta.yml
@@ -11,95 +11,191 @@ tools:
       description: "Compare multiple runs of long read sequencing data and alignments"
       homepage: "https://github.com/wdecoster/nanocomp"
       documentation: "https://github.com/wdecoster/nanocomp"
-      licence: "MIT License"
+      licence: ["MIT License"]
+      identifier: biotools:nanocomp
 input:
-  - meta:
-      type: map
-      description: Groovy Map containing sample information e.g. [ id:'test', single_end:false ]
-  - filelist:
-      type: file
-      description: List of all the files you want to compare, they have to be all the same filetype (either fastq, fasta, bam or Nanopore sequencing summary)
-      pattern: "*.{fastq,fq,fna,ffn,faa,frn,fa,fasta,txt,bam}"
+  - - meta:
+        type: map
+        description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+          ]
+    - filelist:
+        type: file
+        description: List of all the files you want to compare, they have to be all
+          the same filetype (either fastq, fasta, bam or Nanopore sequencing summary)
+        pattern: "*.{fastq,fq,fna,ffn,faa,frn,fa,fasta,txt,bam}"
 output:
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - meta:
-      type: map
-      description: Groovy Map containing sample information e.g. [ id:'test', single_end:false ]
   - report_html:
-      type: file
-      description: Summary of all collected statistics
-      pattern: "*NanoComp-report.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp-report.html":
+          type: file
+          description: Summary of all collected statistics
+          pattern: "*NanoComp-report.html"
   - lengths_violin_html:
-      type: file
-      description: Violin plot of the sequence lengths
-      pattern: "*NanoComp_lengths_violin.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_lengths_violin.html":
+          type: file
+          description: Violin plot of the sequence lengths
+          pattern: "*NanoComp_lengths_violin.html"
   - log_length_violin_html:
-      type: file
-      description: Violin plot of the sequence lengths, log function applied
-      pattern: "*NanoComp_log_length_violin.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_log_length_violin.html":
+          type: file
+          description: Violin plot of the sequence lengths, log function applied
+          pattern: "*NanoComp_log_length_violin.html"
   - n50_html:
-      type: file
-      description: Bar plot of N50 sequence length per sample
-      pattern: "*NanoComp_N50.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_N50.html":
+          type: file
+          description: Bar plot of N50 sequence length per sample
+          pattern: "*NanoComp_N50.html"
   - number_of_reads_html:
-      type: file
-      description: Bar plot of number of reads per sample
-      pattern: "*NanoComp_number_of_reads.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_number_of_reads.html":
+          type: file
+          description: Bar plot of number of reads per sample
+          pattern: "*NanoComp_number_of_reads.html"
   - overlay_histogram_html:
-      type: file
-      description: Histogram of all read lengths per sample
-      pattern: "*NanoComp_OverlayHistogram.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayHistogram.html":
+          type: file
+          description: Histogram of all read lengths per sample
+          pattern: "*NanoComp_OverlayHistogram.html"
   - overlay_histogram_normalized_html:
-      type: file
-      description: Normalized histogram of all read lengths per sample
-      pattern: "*NanoComp_OverlayHistogram_Normalized.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayHistogram_Normalized.html":
+          type: file
+          description: Normalized histogram of all read lengths per sample
+          pattern: "*NanoComp_OverlayHistogram_Normalized.html"
   - overlay_log_histogram_html:
-      type: file
-      description: Histogram of all read lengths per sample, log function applied
-      pattern: "*NanoComp_OverlayLogHistogram.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayLogHistogram.html":
+          type: file
+          description: Histogram of all read lengths per sample, log function applied
+          pattern: "*NanoComp_OverlayLogHistogram.html"
   - overlay_log_histogram_normalized_html:
-      type: file
-      description: Normalized histogram of all read lengths per sample, log function applied
-      pattern: "*NanoComp_OverlayLogHistogram_Normalized.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayLogHistogram_Normalized.html":
+          type: file
+          description: Normalized histogram of all read lengths per sample, log function
+            applied
+          pattern: "*NanoComp_OverlayLogHistogram_Normalized.html"
   - total_throughput_html:
-      type: file
-      description: Barplot comparing throughput in bases
-      pattern: "*NanoComp_total_throughput.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_total_throughput.html":
+          type: file
+          description: Barplot comparing throughput in bases
+          pattern: "*NanoComp_total_throughput.html"
   - quals_violin_html:
-      type: file
-      description: Violin plot of base qualities, only for bam, fastq and sequencing summary input
-      pattern: "*NanoComp_quals_violin.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_quals_violin.html":
+          type: file
+          description: Violin plot of base qualities, only for bam, fastq and sequencing
+            summary input
+          pattern: "*NanoComp_quals_violin.html"
   - overlay_histogram_identity_html:
-      type: file
-      description: Histogram of perfect reference identity, only for bam input
-      pattern: "*NanoComp_OverlayHistogram_Identity.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayHistogram_Identity.html":
+          type: file
+          description: Histogram of perfect reference identity, only for bam input
+          pattern: "*NanoComp_OverlayHistogram_Identity.html"
   - overlay_histogram_phredscore_html:
-      type: file
-      description: Histogram of phred scores, only for bam input
-      pattern: "*NanoComp_OverlayHistogram_PhredScore.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_OverlayHistogram_PhredScore.html":
+          type: file
+          description: Histogram of phred scores, only for bam input
+          pattern: "*NanoComp_OverlayHistogram_PhredScore.html"
   - percent_identity_violin_html:
-      type: file
-      description: Violin plot comparing perfect reference identity, only for bam input
-      pattern: "*NanoComp_percentIdentity_violin.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_percentIdentity_violin.html":
+          type: file
+          description: Violin plot comparing perfect reference identity, only for bam
+            input
+          pattern: "*NanoComp_percentIdentity_violin.html"
   - active_pores_over_time_html:
-      type: file
-      description: Scatter plot of active pores over time, only for sequencing summary input
-      pattern: "*NanoComp_ActivePoresOverTime.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_ActivePoresOverTime.html":
+          type: file
+          description: Scatter plot of active pores over time, only for sequencing summary
+            input
+          pattern: "*NanoComp_ActivePoresOverTime.html"
   - cumulative_yield_plot_gigabases_html:
-      type: file
-      description: Scatter plot of cumulative yield, only for sequencing summary input
-      pattern: "*NanoComp_CumulativeYieldPlot_Gigabases.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_CumulativeYieldPlot_Gigabases.html":
+          type: file
+          description: Scatter plot of cumulative yield, only for sequencing summary input
+          pattern: "*NanoComp_CumulativeYieldPlot_Gigabases.html"
   - sequencing_speed_over_time_html:
-      type: file
-      description: Scatter plot of sequencing speed over time, only for sequencing summary input
-      pattern: "*NanoComp_sequencing_speed_over_time.html"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoComp_sequencing_speed_over_time.html":
+          type: file
+          description: Scatter plot of sequencing speed over time, only for sequencing
+            summary input
+          pattern: "*NanoComp_sequencing_speed_over_time.html"
   - stats_txt:
-      type: file
-      description: txt file with basic statistics
-      pattern: "*NanoStats.txt"
+      - meta:
+          type: map
+          description: Groovy Map containing sample information e.g. [ id:'test', single_end:false
+            ]
+      - "*NanoStats.txt":
+          type: file
+          description: txt file with basic statistics
+          pattern: "*NanoStats.txt"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@paulwolk"
 maintainers:

--- a/modules/nf-core/nanocomp/nanocomp.diff
+++ b/modules/nf-core/nanocomp/nanocomp.diff
@@ -1,4 +1,7 @@
 Changes in module 'nf-core/nanocomp'
+'modules/nf-core/nanocomp/environment.yml' is unchanged
+'modules/nf-core/nanocomp/meta.yml' is unchanged
+Changes in 'nanocomp/main.nf':
 --- modules/nf-core/nanocomp/main.nf
 +++ modules/nf-core/nanocomp/main.nf
 @@ -1,5 +1,6 @@
@@ -9,4 +12,6 @@ Changes in module 'nf-core/nanocomp'
      conda "${moduleDir}/environment.yml"
      container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
 
+'modules/nf-core/nanocomp/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/nanocomp/tests/main.nf.test' is unchanged
 ************************************************************

--- a/modules/nf-core/nanocomp/tests/main.nf.test
+++ b/modules/nf-core/nanocomp/tests/main.nf.test
@@ -1,0 +1,119 @@
+
+nextflow_process {
+
+    name "Test Process NANOCOMP"
+    script "../main.nf"
+    process "NANOCOMP"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "nanocomp"
+
+    test("test-nanocomp-fastq") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id: "test_" ], [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ] ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+					[
+                        process.out.report_html,
+					    process.out.lengths_violin_html,
+					    process.out.log_length_violin_html,
+					    process.out.n50_html,
+					    process.out.number_of_reads_html,
+					    process.out.overlay_histogram_html,
+					    process.out.overlay_histogram_normalized_html,
+					    process.out.overlay_log_histogram_html,
+					    process.out.overlay_log_histogram_normalized_html,
+					    process.out.total_throughput_html,
+					    process.out.quals_violin_html,
+					    process.out.overlay_histogram_identity_html,
+					    process.out.overlay_histogram_phredscore_html,
+					    process.out.percent_identity_violin_html,
+					    process.out.active_pores_over_time_html,
+					    process.out.cumulative_yield_plot_gigabases_html,
+					    process.out.sequencing_speed_over_time_html,
+                        process.out.stats_txt
+                    ]
+                    .findAll { it }
+                    .collect { file(it[0][1]).name }.toSorted(),
+					process.out.versions
+					).match()
+                }
+            )
+        }
+    }
+
+    test("test-nanocomp-summary") {
+
+        when {
+            process {
+                """
+                input[0] = [ [id: "test_"] , [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/sequencing_summary/test.sequencing_summary.txt', checkIfExists: true) ] ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+					[
+                        process.out.report_html,
+					    process.out.lengths_violin_html,
+					    process.out.log_length_violin_html,
+					    process.out.n50_html,
+					    process.out.number_of_reads_html,
+					    process.out.overlay_histogram_html,
+					    process.out.overlay_histogram_normalized_html,
+					    process.out.overlay_log_histogram_html,
+					    process.out.overlay_log_histogram_normalized_html,
+					    process.out.total_throughput_html,
+					    process.out.quals_violin_html,
+					    process.out.overlay_histogram_identity_html,
+					    process.out.overlay_histogram_phredscore_html,
+					    process.out.percent_identity_violin_html,
+					    process.out.active_pores_over_time_html,
+					    process.out.cumulative_yield_plot_gigabases_html,
+					    process.out.sequencing_speed_over_time_html,
+                        process.out.stats_txt
+                    ]
+                    .findAll { it }
+                    .collect { file(it[0][1]).name }.toSorted(),
+					process.out.versions
+					).match()
+                }
+            )
+        }
+    }
+
+    test("test-nanocomp-summary-stub") {
+        options '-stub'
+        when {
+            process {
+                """
+                input[0] = [ [ id: "test_" ], [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/sequencing_summary/test.sequencing_summary.txt', checkIfExists: true) ] ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/nanocomp/tests/main.nf.test.snap
+++ b/modules/nf-core/nanocomp/tests/main.nf.test.snap
@@ -1,0 +1,362 @@
+{
+    "test-nanocomp-summary-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp-report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_lengths_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "10": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_quals_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "11": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_Identity.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "12": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_PhredScore.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "13": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_percentIdentity_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "14": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_ActivePoresOverTime.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "15": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_CumulativeYieldPlot_Gigabases.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "16": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_sequencing_speed_over_time.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "17": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoStats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "18": [
+                    "versions.yml:md5,06252bfc5bdc82345df5755cf53626bb"
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_log_length_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_N50.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_number_of_reads.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_Normalized.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayLogHistogram.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayLogHistogram_Normalized.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "9": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_total_throughput.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "active_pores_over_time_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_ActivePoresOverTime.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cumulative_yield_plot_gigabases_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_CumulativeYieldPlot_Gigabases.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "lengths_violin_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_lengths_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_length_violin_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_log_length_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "n50_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_N50.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "number_of_reads_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_number_of_reads.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_histogram_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_histogram_identity_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_Identity.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_histogram_normalized_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_Normalized.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_histogram_phredscore_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayHistogram_PhredScore.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_log_histogram_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayLogHistogram.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "overlay_log_histogram_normalized_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_OverlayLogHistogram_Normalized.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "percent_identity_violin_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_percentIdentity_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "quals_violin_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_quals_violin.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "report_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp-report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sequencing_speed_over_time_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_sequencing_speed_over_time.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stats_txt": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoStats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "total_throughput_html": [
+                    [
+                        {
+                            "id": "test_"
+                        },
+                        "test_NanoComp_total_throughput.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,06252bfc5bdc82345df5755cf53626bb"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-30T21:31:29.992878"
+    },
+    "test-nanocomp-summary": {
+        "content": [
+            [
+                "test_NanoComp-report.html",
+                "test_NanoComp_ActivePoresOverTime.html",
+                "test_NanoComp_CumulativeYieldPlot_Gigabases.html",
+                "test_NanoComp_N50.html",
+                "test_NanoComp_OverlayHistogram.html",
+                "test_NanoComp_OverlayHistogram_Normalized.html",
+                "test_NanoComp_OverlayLogHistogram.html",
+                "test_NanoComp_OverlayLogHistogram_Normalized.html",
+                "test_NanoComp_lengths_violin.html",
+                "test_NanoComp_log_length_violin.html",
+                "test_NanoComp_number_of_reads.html",
+                "test_NanoComp_quals_violin.html",
+                "test_NanoComp_sequencing_speed_over_time.html",
+                "test_NanoComp_total_throughput.html",
+                "test_NanoStats.txt"
+            ],
+            [
+                "versions.yml:md5,06252bfc5bdc82345df5755cf53626bb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-02T15:03:32.866863"
+    },
+    "test-nanocomp-fastq": {
+        "content": [
+            [
+                "test_NanoComp-report.html",
+                "test_NanoComp_N50.html",
+                "test_NanoComp_OverlayHistogram.html",
+                "test_NanoComp_OverlayHistogram_Normalized.html",
+                "test_NanoComp_OverlayLogHistogram.html",
+                "test_NanoComp_OverlayLogHistogram_Normalized.html",
+                "test_NanoComp_lengths_violin.html",
+                "test_NanoComp_log_length_violin.html",
+                "test_NanoComp_number_of_reads.html",
+                "test_NanoComp_quals_violin.html",
+                "test_NanoComp_total_throughput.html",
+                "test_NanoStats.txt"
+            ],
+            [
+                "versions.yml:md5,06252bfc5bdc82345df5755cf53626bb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-02T15:02:58.745416"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/nf-core/scnanoseq/issues/62 by updating the `nanocomp` module to latest.

Also tweaked the `.gitignore` file to move the custom stuff to the top - if it's there then the linting passes fine, it only fails when there is custom stuff in the middle of the template content.

I also fixed the `.nf-core.yml` file that had invalid syntax for `pipeline_todos` (should be boolean). But there aren't any `TODO` statements in those files any more anyway, so I just removed that.

Note that I didn't do the following, which probably should be done at some point:

* Template sync to latest
* Update all modules

Looks like there haven't been any automated template sync PRs here for a while 🤔 Let's follow up on Slack as to why that might be.