### PR TITLE
Resume fix

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1008,7 +1008,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/${meta.sample_name}/genome/isoquant/output/" },
+            path: { "${params.outdir}/${meta.id}/genome/isoquant/output/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/subworkflows/local/dedup_umis.nf
+++ b/subworkflows/local/dedup_umis.nf
@@ -55,12 +55,12 @@ workflow DEDUP_UMIS {
                     .flatten()
                     .map{
                         bam ->
-                            bam_basename = bam.toString().split('/')[-1]
-                            split_bam_basename = bam_basename.split(/\./)
-                            meta = [
+                            def bam_basename = bam.toString().split('/')[-1]
+                            def split_bam_basename = bam_basename.split(/\./)
+                            def new_meta = [
                                 'id': split_bam_basename.take(split_bam_basename.size()-1).join("."),
                             ]
-                            [ meta, bam ]
+                            [ new_meta, bam ]
                     }
 
             } else {
@@ -83,8 +83,8 @@ workflow DEDUP_UMIS {
                         .combine(GROUP_TRANSCRIPTS.out.grouped_transcripts.flatten())
                         .map{
                             meta, bam, bai, region ->
-                                region_basename = region.toString().split('/')[-1]
-                                split_region_basename = region_basename.split(/\./)
+                                def region_basename = region.toString().split('/')[-1]
+                                def split_region_basename = region_basename.split(/\./)
                                 [['id': meta.id + "." + split_region_basename[0]], bam, bai, region]
                         },
                     [[],[]],
@@ -151,10 +151,10 @@ workflow DEDUP_UMIS {
                     ch_dedup_bam
                     .map{
                         meta, bam ->
-                            bam_basename = bam.toString().split('/')[-1]
-                            split_bam_basename = bam_basename.split(/\./)
-                            meta = [ 'id': split_bam_basename[0] ]
-                        [ meta, bam ]
+                            def bam_basename = bam.toString().split('/')[-1]
+                            def split_bam_basename = bam_basename.split(/\./)
+                            def new_meta = [ 'id': split_bam_basename[0] ]
+                        [ new_meta, bam ]
                     }
                     .groupTuple(),
                 fasta,

--- a/subworkflows/local/quantify_scrna_isoquant.nf
+++ b/subworkflows/local/quantify_scrna_isoquant.nf
@@ -65,7 +65,7 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
         BAMTOOLS_SPLIT ( in_bam )
         ch_versions = ch_versions.mix(BAMTOOLS_SPLIT.out.versions.first())
         ch_split_bam = BAMTOOLS_SPLIT.out.bam
-            .map { meta, bam -> 
+            .map { meta, bam ->
                 def bam_basename = bam.toString().split('/')[-1]
                 def chrom = bam_basename.split(/\./)[1].replace("REF_", "")
                 def new_meta = meta + [ 'chr': chrom ]
@@ -78,7 +78,7 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
         SAMTOOLS_INDEX_SPLIT( ch_split_bam )
         ch_split_bai = SAMTOOLS_INDEX_SPLIT.out.bai
         ch_versions = ch_versions.mix(SAMTOOLS_INDEX_SPLIT.out.versions.first())
-    
+
         // Prepare isoquant input channel
         // bam and bai files need to be joined with split fasta, fai and gtf files
         isoquant_input = ch_split_bam
@@ -93,7 +93,7 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
             .map { chrom, meta, bam, bai, fasta, fai, gtf ->
                 [ meta, bam, bai, fasta, fai, gtf ]
             }
-    
+
         //
         // MODULE: Isoquant
         //

--- a/subworkflows/local/quantify_scrna_isoquant.nf
+++ b/subworkflows/local/quantify_scrna_isoquant.nf
@@ -36,9 +36,9 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
             .flatten()
             .map{
                 fasta ->
-                    fasta_basename = fasta.toString().split('/')[-1]
-                    meta = [ 'chr': fasta_basename.split(/\./)[0] ]
-                    [ meta, fasta ]
+                    def fasta_basename = fasta.toString().split('/')[-1]
+                    def new_meta = [ 'chr': fasta_basename.split(/\./)[0] ]
+                    [ new_meta, fasta ]
             }
 
         SAMTOOLS_FAIDX_SPLIT( ch_split_fasta, [ [:], "$projectDir/assets/dummy_file.txt" ])
@@ -53,9 +53,9 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
             .flatten()
             .map{
                 gtf ->
-                    gtf_basename = gtf.toString().split('/')[-1]
-                    meta = ['chr': gtf_basename.split(/\./)[0]]
-                    [ meta, gtf ]
+                    def gtf_basename = gtf.toString().split('/')[-1]
+                    def new_meta = ['chr': gtf_basename.split(/\./)[0]]
+                    [ new_meta, gtf ]
             }
         ch_versions = ch_versions.mix(SPLIT_GTF.out.versions)
 
@@ -65,19 +65,11 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
         BAMTOOLS_SPLIT ( in_bam )
         ch_versions = ch_versions.mix(BAMTOOLS_SPLIT.out.versions.first())
         ch_split_bam = BAMTOOLS_SPLIT.out.bam
-            .map{
-                meta, bam ->
-                    [bam]
-            }
-            .flatten()
-            .map{
-                bam ->
-                    bam_basename = bam.toString().split('/')[-1]
-                    split_bam_basename = bam_basename.split(/\./)
-                    meta = [
-                        'id': split_bam_basename.take(split_bam_basename.size()-1).join("."),
-                    ]
-                    [ meta, bam ]
+            .map { meta, bam -> 
+                def bam_basename = bam.toString().split('/')[-1]
+                def chrom = bam_basename.split(/\./)[1].replace("REF_", "")
+                def new_meta = meta + [ 'chr': chrom ]
+                return [ new_meta, bam ]
             }
 
         //
@@ -86,31 +78,27 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
         SAMTOOLS_INDEX_SPLIT( ch_split_bam )
         ch_split_bai = SAMTOOLS_INDEX_SPLIT.out.bai
         ch_versions = ch_versions.mix(SAMTOOLS_INDEX_SPLIT.out.versions.first())
-
+    
+        // Prepare isoquant input channel
+        // bam and bai files need to be joined with split fasta, fai and gtf files
+        isoquant_input = ch_split_bam
+            .join(ch_split_bai, by: [0])
+            .map { meta, bam, bai ->
+                def chrom = [ 'chr': meta.chr ]
+                [ chrom, meta, bam, bai ]
+            }
+            .combine(ch_split_fasta, by: [0])
+            .combine(ch_split_fai, by: [0])
+            .combine(ch_split_gtf, by: [0])
+            .map { chrom, meta, bam, bai, fasta, fai, gtf ->
+                [ meta, bam, bai, fasta, fai, gtf ]
+            }
+    
         //
         // MODULE: Isoquant
         //
         ISOQUANT (
-            ch_split_bam
-                .join(ch_split_bai, by: [0])
-                .map{
-                    meta, bam, bai ->
-                        bam_basename = bam.toString().split('/')[-1]
-                        split_bam_basename = bam_basename.split(/\./)
-                        chr = [
-                            'chr': split_bam_basename[1].replace("REF_","")
-                        ]
-                        [ chr, meta, bam, bai]
-                }
-                .combine(ch_split_fasta, by: [0])
-                .combine(ch_split_fai, by: [0])
-                .combine(ch_split_gtf, by: [0])
-                .map{
-                    chr, meta, bam, bai, fasta, fai, gtf ->
-                        meta.sample_name = meta.id.split(/\./)[0]
-                        meta.chr = meta.id.split(/\./)[1]
-                        [ meta, bam, bai, fasta, fai, gtf ]
-                },
+            isoquant_input,
             'tag:CB'
         )
         ch_versions = ch_versions.mix(ISOQUANT.out.versions)
@@ -120,12 +108,11 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
         //
         MERGE_MTX_GENE (
             ISOQUANT.out.grouped_gene_counts
-                .map{
-                    meta, mtx ->
-                        basename = mtx.toString().split('/')[-1]
-                        split_basename = basename.split(/\./)
-                        meta = [ 'id': split_basename[0] ]
-                    [ meta, mtx ]
+                .map{ meta, mtx ->
+                    def basename = mtx.toString().split('/')[-1]
+                    def split_basename = basename.split(/\./)
+                    def new_meta = [ 'id': split_basename[0] ]
+                    [ new_meta, mtx ]
                 }
                 .groupTuple()
         )
@@ -136,10 +123,10 @@ workflow QUANTIFY_SCRNA_ISOQUANT {
             ISOQUANT.out.grouped_transcript_counts
                 .map{
                     meta, mtx ->
-                        basename = mtx.toString().split('/')[-1]
-                        split_basename = basename.split(/\./)
-                        meta = [ 'id': split_basename[0] ]
-                    [ meta, mtx ]
+                        def basename = mtx.toString().split('/')[-1]
+                        def split_basename = basename.split(/\./)
+                        def new_meta = [ 'id': split_basename[0] ]
+                    [ new_meta, mtx ]
                 }
                 .groupTuple()
         )


### PR DESCRIPTION
Changes to formatting of `meta` so that it doesnt get overwritten and messes up `-resume`. This was giving issues with `isoquant` but I've also fixed it in other locations (umi dedup subworkflow). 

Important to note:
When creating a new meta map, always ensure that first a new map is created. Additionally, using `def x = ...` instead of `x = ...` will make sure that the variable only exists without the closures, resulting in less chance of variables being overwritten.

<!--
# nf-core/scnanoseq pull request

Many thanks for contributing to nf-core/scnanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scnanoseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
