### PR TITLE
Add Parabricks GPU-accelerated minimap2 to the scnanoseq pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ params.yml
 samplesheet.csv
 *.swp
 input*
+.nf-test*

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ samplesheet.csv
 input*
 null/
 tmp/
+.nf-test*

--- a/align_longreads_test.log
+++ b/align_longreads_test.log
@@ -1,0 +1,614 @@
+
+🚀[1m nf-test 0.9.3[0m
+https://www.nf-test.com
+(c) 2021 - 2024 Lukas Forer and Sebastian Schoenherr
+
+Load .nf-test/plugins/nft-bam/0.4.0/nft-bam-0.4.0.jar
+Load .nf-test/plugins/nft-utils/0.0.5/nft-utils-0.0.5.jar
+Warning: every snapshot that fails during this test run is re-recorded.
+
+[1mTest Subworkflow ALIGN_LONGREADS[0m
+
+  [1mTest[0m [f3466bcc] 'align_longreads - default params' 
+    > N E X T F L O W  ~  version 25.10.4
+    > Launching `/home/gburnett/scnanoseq/.nf-test-f3466bccbc2e174daabd0609ed7ea661.nf` [nasty_shockley] DSL2 - revision: ae6c664832
+    > WARN: There's no process matching config selector: CUSTOM_DUMPSOFTWAREVERSIONS
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_PRE_TRIM:FASTQC
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_TRIM:FASTQC
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_EXTRACT:FASTQC
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_PRE_TRIM:NANOPLOT
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_TRIM:NANOPLOT
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_EXTRACT:NANOPLOT
+    > WARN: There's no process matching config selector: .*:NANOCOMP_FASTQ
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_PRE_TRIM:TOULLIGQC
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_TRIM:TOULLIGQC
+    > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_EXTRACT:TOULLIGQC
+    > WARN: There's no process matching config selector: .*:BAM_SORT_STATS_SAMTOOLS_CORRECTED:BAM_STATS_SAMTOOLS:.*
+    > WARN: There's no process matching config selector: .*:READ_COUNTS
+    > WARN: There's no process matching config selector: .*:PREPARE_REFERENCE_FILES:.*
+    > WARN: There's no process matching config selector: .*:UCSC_GTFTOGENEPRED
+    > WARN: There's no process matching config selector: .*:UCSC_GENEPREDTOBED
+    > WARN: There's no process matching config selector: .*:GUNZIP_WHITELIST.*
+    > WARN: There's no process matching config selector: .*:CAT_FASTQ
+    > WARN: There's no process matching config selector: .*:PIGZ_UNCOMPRESS.*
+    > WARN: There's no process matching config selector: .*:GUNZIP_FASTQ.*
+    > WARN: There's no process matching config selector: .*:NANOFILT
+    > WARN: There's no process matching config selector: .*:BLAZE
+    > WARN: There's no process matching config selector: .*:PREEXTRACT_FASTQ
+    > WARN: There's no process matching config selector: .*:CORRECT_BARCODES
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:TAG_BARCODES
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:TAG_BARCODES
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:SAMTOOLS_INDEX_TAGGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:SAMTOOLS_INDEX_TAGGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:SAMTOOLS_FLAGSTAT_TAGGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:SAMTOOLS_FLAGSTAT_TAGGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:MINIMAP2_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:MINIMAP2_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:MINIMAP2_ALIGN
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:MINIMAP2_ALIGN
+    > WARN: There's no process matching config selector: .*:SAMTOOLS_FILTER_DEDUP
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:RSEQC_READDISTRIBUTION
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:RSEQC_READDISTRIBUTION
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:ALIGN_LONGREADS:NANOCOMP
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:ALIGN_LONGREADS:NANOCOMP
+    > WARN: There's no process matching config selector: .*:BAM_SORT_STATS_SAMTOOLS_CORRECTED:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*:BAM_SORT_STATS_SAMTOOLS_MERGED:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*:BAM_SORT_STATS_SAMTOOLS_CORRECTED:SAMTOOLS_INDEX
+    > WARN: There's no process matching config selector: .*:GROUP_TRANSCRIPTS
+    > WARN: There's no process matching config selector: .*:SAMTOOLS_VIEW_SPLIT
+    > WARN: There's no process matching config selector: .*:SPLIT_BAM
+    > WARN: There's no process matching config selector: .*:DEDUP_UMIS:BAM_SORT_STATS_SAMTOOLS.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:UMITOOLS_DEDUP
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:PICARD_MARKDUPLICATES
+    > WARN: There's no process matching config selector: .*:PROCESS_LONGREAD_SCRNA_TRANSCRIPT:DEDUP_UMIS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*:SAMTOOLS_INDEX_DEDUP
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*DEDUP_UMIS:SAMTOOLS_MERGE
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*DEDUP_UMIS:SAMTOOLS_INDEX_MERGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_TRANSCRIPT.*DEDUP_UMIS:BAM_STATS_SAMTOOLS.*
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:UMITOOLS_DEDUP
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:PICARD_MARKDUPLICATES
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*:SAMTOOLS_INDEX_DEDUP
+    > WARN: There's no process matching config selector: .*:PROCESS_LONGREAD_SCRNA_GENOME:DEDUP_UMIS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*DEDUP_UMIS:SAMTOOLS_MERGE
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*DEDUP_UMIS:SAMTOOLS_INDEX_MERGED
+    > WARN: There's no process matching config selector: .*PROCESS_LONGREAD_SCRNA_GENOME.*DEDUP_UMIS:BAM_STATS_SAMTOOLS.*
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_ISOQUANT:SPLIT_FASTA
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_ISOQUANT:SAMTOOLS_FAIDX_SPLIT
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_ISOQUANT:SPLIT_GTF
+    > WARN: There's no process matching config selector: .*:BAMTOOLS_SPLIT
+    > WARN: There's no process matching config selector: .*:SAMTOOLS_INDEX_SPLIT
+    > WARN: There's no process matching config selector: .*:ISOQUANT
+    > WARN: There's no process matching config selector: .*:MERGE_MTX_GENE
+    > WARN: There's no process matching config selector: .*:MERGE_MTX_TRANSCRIPT
+    > WARN: There's no process matching config selector: .*QUANTIFY_SCRNA_ISOQUANT:QC_SCRNA_GENE:SEURAT
+    > WARN: There's no process matching config selector: .*QUANTIFY_SCRNA_ISOQUANT:QC_SCRNA_TRANSCRIPT:SEURAT
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_ISOQUANT:QC_SCRNA_GENE:COMBINE_SEURAT_STATS
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_ISOQUANT:QC_SCRNA_TRANSCRIPT:COMBINE_SEURAT_STATS
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_OARFISH:SAMTOOLS_SORT
+    > WARN: There's no process matching config selector: .*:OARFISH
+    > WARN: There's no process matching config selector: .*QUANTIFY_SCRNA_OARFISH:QC_SCRNA:SEURAT
+    > WARN: There's no process matching config selector: .*:QUANTIFY_SCRNA_OARFISH:QC_SCRNA:COMBINE_SEURAT_STATS
+    > WARN: There's no process matching config selector: .*:MULTIQC_FINALQC
+    > WARN: There's no process matching config selector: .*:MULTIQC_RAWQC
+    > WARN: There's no process matching config selector: .*:PARABRICKS_MINIMAP2 -- Did you mean: PARABRICKS_MINIMAP2?
+    > [SAMTOOLS_FAIDX (1)] cache hash: affd1666cdfc37f409a509fcc9913f1f; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   67936df68d1f1d713a071f5e5bb51c0a [java.lang.String] SAMTOOLS_FAIDX 
+    >   5a5f32387a9840d2a43752aa5fe956c0 [java.lang.String]     def args = task.ext.args ?: ''
+    >     """
+    >     samtools \\
+    >         faidx \\
+    >         $fasta \\
+    >         $args
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   5d4b4312c0f9bce3dde0445bff2b3280 [java.lang.String] fai 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
+    > 
+    > [52/b6bccc] Submitted process > SAMTOOLS_FAIDX (genome.fasta)
+    > [ALIGN_LONGREADS:MINIMAP2_INDEX (1)] cache hash: d2ea43324d02ead2da02c7b8d351b652; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   0c14d7c17dfa8b220990f0a5c2476c6d [java.lang.String] ALIGN_LONGREADS:MINIMAP2_INDEX 
+    >   86e3905eb02cd6389193a0c77375bacc [java.lang.String]     def args = task.ext.args ?: ''
+    >     """
+    >     minimap2 \\
+    >         -t $task.cpus \\
+    >         -d ${fasta.baseName}.mmi \\
+    >         $args \\
+    >         $fasta
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         minimap2: \$(minimap2 --version 2>&1)
+    >     END_VERSIONS
+    >     """
+    >  
+    >   d41a03883af0572e320680dc8c580b68 [java.lang.String] quay.io/biocontainers/minimap2:2.28--he4a0461_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
+    > 
+    > [90/e63d05] Submitted process > ALIGN_LONGREADS:MINIMAP2_INDEX (1)
+    > [ALIGN_LONGREADS:MINIMAP2_ALIGN (1)] cache hash: add9a12c9d80230afb74fb2f9014a074; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   67b217f2d710bf9797dbfec7fa7ae42b [java.lang.String] ALIGN_LONGREADS:MINIMAP2_ALIGN 
+    >   d1bf10bf50b1058281d4362afa5d73b7 [java.lang.String]     def args  = task.ext.args ?: ''
+    >     def args2 = task.ext.args2 ?: ''
+    >     def args3 = task.ext.args3 ?: ''
+    >     def args4 = task.ext.args4 ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def bam_index = bam_index_extension ? "${prefix}.bam##idx##${prefix}.bam.${bam_index_extension} --write-index" : "${prefix}.bam"
+    >     def bam_output = bam_format ? "-a | samtools sort -@ ${task.cpus-1} -o ${bam_index} ${args2}" : "-o ${prefix}.paf"
+    >     def cigar_paf = cigar_paf_format && !bam_format ? "-c" : ''
+    >     def set_cigar_bam = cigar_bam && bam_format ? "-L" : ''
+    >     def bam_input = "${reads.extension}".matches('sam|bam|cram')
+    >     def samtools_reset_fastq = bam_input ? "samtools reset --threads ${task.cpus-1} $args3 $reads | samtools fastq --threads ${task.cpus-1} $args4 |" : ''
+    >     def query = bam_input ? "-" : reads
+    >     def target = reference ?: (bam_input ? error("BAM input requires reference") : reads)
+    >     """
+    >     $samtools_reset_fastq \\
+    >     minimap2 \\
+    >         $args \\
+    >         -t $task.cpus \\
+    >         $target \\
+    >         $query \\
+    >         $cigar_paf \\
+    >         $set_cigar_bam \\
+    >         $bam_output
+    > 
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         minimap2: \$(minimap2 --version 2>&1)
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fb7bfb4268792db810e6f93de6045e1b [java.lang.String] quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:3161f532a5ea6f1dec9be5667c9efc2afdac6104-0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   553096c532e666fb42214fdf0520fe4a [java.lang.String] reads 
+    >   fcd1c71adb77600bd10a213700e2a51f [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/bc/6b6e27f642bf3c1117aa944babf940/test_1.fastq.gz, stageName:test_1.fastq.gz, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   fec83c41a7c57f821d28e6b995ac3b35 [java.lang.String] reference 
+    >   be0ba66161bae7cf11972a73c8e9572f [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi, stageName:genome.mmi, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi)] 
+    >   ccf1f8711aa211801cb5ed01bb124b46 [java.lang.String] bam_format 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   402650ce03fd207c926dd4b70f4b2134 [java.lang.String] bam_index_extension 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   3fb18579fe9f1742c9ae616db7578057 [java.lang.String] cigar_paf_format 
+    >   00000000000000000000000000000000 [java.lang.String]  
+    >   a6a266995496c3a378cf6f5a77149c72 [java.lang.String] cigar_bam 
+    >   00000000000000000000000000000000 [java.lang.String]  
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   65ccae5e10ea815eb0beb62fe94e8c4e [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.args3=null, task.ext.args4=null, task.ext.args2=null, task.ext.prefix=null] 
+    > 
+    > [04/60155a] Submitted process > ALIGN_LONGREADS:MINIMAP2_ALIGN (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (1)] cache hash: b708f26236f137f7c402d2a847ce0fe2; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   19597c784cc32a26ec7276b94c681d03 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT 
+    >   8a12e0d8fd605821210f2df15089a5d8 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def extension = args.contains("--output-fmt sam") ? "sam" :
+    >                     args.contains("--output-fmt cram") ? "cram" :
+    >                     "bam"
+    >     def reference = fasta ? "--reference ${fasta}" : ""
+    >     if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    >     """
+    >     samtools cat \\
+    >         --threads $task.cpus \\
+    >         ${bam} \\
+    >     | \\
+    >     samtools sort \\
+    >         $args \\
+    >         -T ${prefix} \\
+    >         --threads $task.cpus \\
+    >         ${reference} \\
+    >         -o ${prefix}.${extension} \\
+    >         -
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   37925e00c2c867a364e7fa1d52ae9bfd [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam, stageName:test_fastq.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   4dccca5e99f704ee07fa6381a6d3970c [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=wacky] 
+    > 
+    > [ae/28c236] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (1)] cache hash: 3cf0045b390965e1b403b76d0b327459; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   1dbe8482c60cf28c6f1fff9bddad7be9 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX 
+    >   5b95d9cf4a85564d79fcd6e37614402a [java.lang.String]     def args = task.ext.args ?: ''
+    >     """
+    >     samtools \\
+    >         index \\
+    >         -@ ${task.cpus-1} \\
+    >         $args \\
+    >         $input
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
+    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
+    > 
+    > [a4/a4ab7c] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: c00f64b046b26be7a8ef9b0cfaa38910; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   19c70dc0acb85da0849ad9e9b359324c [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS 
+    >   7fd9f9a46edf86abe81cb84b1dac8efe [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         idxstats \\
+    >         --threads ${task.cpus-1} \\
+    >         $bam \\
+    >         > ${prefix}.idxstats
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: 4f5be177c546a62dc03e56f4906ad937; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   a8b78c9b89b8369ff378e1391d48acd3 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
+    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         flagstat \\
+    >         --threads ${task.cpus} \\
+    >         $bam \\
+    >         > ${prefix}.flagstat
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (1)] cache hash: 86ba2208adba45372b1e8b0e705a0ea7; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   8d5689acd6ac69486a8a5111828e8d76 [java.lang.String] ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED 
+    >   9fec9060a5e33920153548a33177c01a [java.lang.String]     def args = task.ext.args ?: ''
+    >     def args2 = task.ext.args2 ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def reference = fasta ? "--reference ${fasta}" : ""
+    >     def readnames = qname ? "--qname-file ${qname}": ""
+    >     def file_type = args.contains("--output-fmt sam") ? "sam" :
+    >                     args.contains("--output-fmt bam") ? "bam" :
+    >                     args.contains("--output-fmt cram") ? "cram" :
+    >                     input.getExtension()
+    >     def region_names = regions ? "`cat ${regions}`" : ""
+    >     if ("$input" == "${prefix}.${file_type}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    >     """
+    >     samtools \\
+    >         view \\
+    >         --threads ${task.cpus-1} \\
+    >         ${reference} \\
+    >         ${readnames} \\
+    >         $args \\
+    >         -o ${prefix}.${file_type} \\
+    >         $input \\
+    >         $args2 \\
+    >         $region_names
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
+    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   105e03d70ef5c389e573ff1c323ba2e5 [java.lang.String] index 
+    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   c187e49e2c9ca85c0cb9ee223c78ba6b [java.lang.String] regions 
+    >   3ff3e3f046770a9decf4860d590e6a5a [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/assets/dummy_file.txt, storePath:/home/gburnett/scnanoseq/assets/dummy_file.txt, stageName:dummy_file.txt, sourcePath:/home/gburnett/scnanoseq/assets/dummy_file.txt)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   adee635784e2c152e01dba59a781d8c8 [java.lang.String] qname 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   2d55a1346381340a801aeecc91d4cf47 [java.util.HashMap$EntrySet] [task.ext.args=-b -F 4, task.ext.args2=null, task.ext.prefix=test_fastq.mapped_only] 
+    > 
+    > [7d/47ec23] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
+    > [cd/8b0034] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
+    > [b1/49c493] Submitted process > ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: f40526340ca4d2ff96042e73573ffe0c; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   f9d654fd115b60d466dabc9b2d9abe24 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS 
+    >   07db10f64f92ff5b77c8bf2cb0d8f4d3 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def reference = fasta ? "--reference ${fasta}" : ""
+    >     """
+    >     samtools \\
+    >         stats \\
+    >         --threads ${task.cpus} \\
+    >         ${reference} \\
+    >         ${input} \\
+    >         > ${prefix}.stats
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
+    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   f792a6941a7c8fee95aa4475972a289a [java.lang.String] input_index 
+    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [60/2984df] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (1)] cache hash: 16cf5ff6ccc3f931526fadc320265b0e; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   9cd3f28b6559f14af3b7ef3cb63f560b [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT 
+    >   8a12e0d8fd605821210f2df15089a5d8 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def extension = args.contains("--output-fmt sam") ? "sam" :
+    >                     args.contains("--output-fmt cram") ? "cram" :
+    >                     "bam"
+    >     def reference = fasta ? "--reference ${fasta}" : ""
+    >     if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    >     """
+    >     samtools cat \\
+    >         --threads $task.cpus \\
+    >         ${bam} \\
+    >     | \\
+    >     samtools sort \\
+    >         $args \\
+    >         -T ${prefix} \\
+    >         --threads $task.cpus \\
+    >         ${reference} \\
+    >         -o ${prefix}.${extension} \\
+    >         -
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   2b8b3eb344c845d87bae23130a1eb8ed [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam, stageName:test_fastq.mapped_only.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   4dccca5e99f704ee07fa6381a6d3970c [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=wacky] 
+    > 
+    > [5a/f6c5ef] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (1)] cache hash: e46f3c402f7a11d8aa10d31ebd972a2f; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   c2141a6b0bbb3d6a91c365c4e35915f9 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX 
+    >   5b95d9cf4a85564d79fcd6e37614402a [java.lang.String]     def args = task.ext.args ?: ''
+    >     """
+    >     samtools \\
+    >         index \\
+    >         -@ ${task.cpus-1} \\
+    >         $args \\
+    >         $input
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
+    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
+    > 
+    > [ab/389095] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: 667a8b7848ceda6b47380a77e7164710; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   ae1edbc966f96699047514860364f009 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
+    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         flagstat \\
+    >         --threads ${task.cpus} \\
+    >         $bam \\
+    >         > ${prefix}.flagstat
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: 4ae1676fee08b23f8355389c69a26c44; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   7a314d556faf59f8cfe741e410e44c94 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS 
+    >   7fd9f9a46edf86abe81cb84b1dac8efe [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         idxstats \\
+    >         --threads ${task.cpus-1} \\
+    >         $bam \\
+    >         > ${prefix}.idxstats
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [32/6038ae] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
+    > [69/82aa9e] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: f2049fe5fbbcc14cec794c601758bf6e; mode: STANDARD; entries: 
+    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    >   4a3ec838ac78469de18ab9b0200dc189 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS 
+    >   07db10f64f92ff5b77c8bf2cb0d8f4d3 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def reference = fasta ? "--reference ${fasta}" : ""
+    >     """
+    >     samtools \\
+    >         stats \\
+    >         --threads ${task.cpus} \\
+    >         ${reference} \\
+    >         ${input} \\
+    >         > ${prefix}.stats
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
+    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   f792a6941a7c8fee95aa4475972a289a [java.lang.String] input_index 
+    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [3e/0b13dd] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
+    [32mPASSED[0m (29.199s)
+  Snapshots:
+    1 created [align_longreads - default params]
+    Obsolete snapshots can only be checked if all tests of a file are executed successful.
+
+
+Snapshot Summary:
+  1 created
+
+[1m[32mSUCCESS: [0m[0mExecuted 1 tests in 29.211s
+

--- a/align_longreads_test.log
+++ b/align_longreads_test.log
@@ -9,9 +9,9 @@ Warning: every snapshot that fails during this test run is re-recorded.
 
 [1mTest Subworkflow ALIGN_LONGREADS[0m
 
-  [1mTest[0m [f3466bcc] 'align_longreads - default params' 
+  [1mTest[0m [d7ceeceb] 'align_longreads - gpu params' 
     > N E X T F L O W  ~  version 25.10.4
-    > Launching `/home/gburnett/scnanoseq/.nf-test-f3466bccbc2e174daabd0609ed7ea661.nf` [nasty_shockley] DSL2 - revision: ae6c664832
+    > Launching `/home/gburnett/scnanoseq/.nf-test-d7ceecebe6e1d32045c871b5bf3679c6.nf` [gigantic_cori] DSL2 - revision: 917437512c
     > WARN: There's no process matching config selector: CUSTOM_DUMPSOFTWAREVERSIONS
     > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_PRE_TRIM:FASTQC
     > WARN: There's no process matching config selector: .*:FASTQC_NANOPLOT_POST_TRIM:FASTQC
@@ -103,38 +103,8 @@ Warning: every snapshot that fails during this test run is re-recorded.
     > WARN: There's no process matching config selector: .*:MULTIQC_FINALQC
     > WARN: There's no process matching config selector: .*:MULTIQC_RAWQC
     > WARN: There's no process matching config selector: .*:PARABRICKS_MINIMAP2 -- Did you mean: PARABRICKS_MINIMAP2?
-    > [SAMTOOLS_FAIDX (1)] cache hash: affd1666cdfc37f409a509fcc9913f1f; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
-    >   67936df68d1f1d713a071f5e5bb51c0a [java.lang.String] SAMTOOLS_FAIDX 
-    >   5a5f32387a9840d2a43752aa5fe956c0 [java.lang.String]     def args = task.ext.args ?: ''
-    >     """
-    >     samtools \\
-    >         faidx \\
-    >         $fasta \\
-    >         $args
-    > 
-    >     cat <<-END_VERSIONS > versions.yml
-    >     "${task.process}":
-    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    >     END_VERSIONS
-    >     """
-    >  
-    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
-    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
-    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
-    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
-    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
-    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
-    >   5d4b4312c0f9bce3dde0445bff2b3280 [java.lang.String] fai 
-    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
-    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
-    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
-    > 
-    > [52/b6bccc] Submitted process > SAMTOOLS_FAIDX (genome.fasta)
-    > [ALIGN_LONGREADS:MINIMAP2_INDEX (1)] cache hash: d2ea43324d02ead2da02c7b8d351b652; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [ALIGN_LONGREADS:MINIMAP2_INDEX (1)] cache hash: 889acaa25ccfaf1620b4c5befa83551b; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   0c14d7c17dfa8b220990f0a5c2476c6d [java.lang.String] ALIGN_LONGREADS:MINIMAP2_INDEX 
     >   86e3905eb02cd6389193a0c77375bacc [java.lang.String]     def args = task.ext.args ?: ''
     >     """
@@ -154,71 +124,112 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
     >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
     > 
-    > [90/e63d05] Submitted process > ALIGN_LONGREADS:MINIMAP2_INDEX (1)
-    > [ALIGN_LONGREADS:MINIMAP2_ALIGN (1)] cache hash: add9a12c9d80230afb74fb2f9014a074; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
-    >   67b217f2d710bf9797dbfec7fa7ae42b [java.lang.String] ALIGN_LONGREADS:MINIMAP2_ALIGN 
-    >   d1bf10bf50b1058281d4362afa5d73b7 [java.lang.String]     def args  = task.ext.args ?: ''
-    >     def args2 = task.ext.args2 ?: ''
-    >     def args3 = task.ext.args3 ?: ''
-    >     def args4 = task.ext.args4 ?: ''
-    >     def prefix = task.ext.prefix ?: "${meta.id}"
-    >     def bam_index = bam_index_extension ? "${prefix}.bam##idx##${prefix}.bam.${bam_index_extension} --write-index" : "${prefix}.bam"
-    >     def bam_output = bam_format ? "-a | samtools sort -@ ${task.cpus-1} -o ${bam_index} ${args2}" : "-o ${prefix}.paf"
-    >     def cigar_paf = cigar_paf_format && !bam_format ? "-c" : ''
-    >     def set_cigar_bam = cigar_bam && bam_format ? "-L" : ''
-    >     def bam_input = "${reads.extension}".matches('sam|bam|cram')
-    >     def samtools_reset_fastq = bam_input ? "samtools reset --threads ${task.cpus-1} $args3 $reads | samtools fastq --threads ${task.cpus-1} $args4 |" : ''
-    >     def query = bam_input ? "-" : reads
-    >     def target = reference ?: (bam_input ? error("BAM input requires reference") : reads)
+    > [1b/3cd35f] Submitted process > ALIGN_LONGREADS:MINIMAP2_INDEX (1)
+    > [SAMTOOLS_FAIDX (1)] cache hash: 271a68143527d8aa780e232aeb432d81; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
+    >   67936df68d1f1d713a071f5e5bb51c0a [java.lang.String] SAMTOOLS_FAIDX 
+    >   5a5f32387a9840d2a43752aa5fe956c0 [java.lang.String]     def args = task.ext.args ?: ''
     >     """
-    >     $samtools_reset_fastq \\
-    >     minimap2 \\
-    >         $args \\
-    >         -t $task.cpus \\
-    >         $target \\
-    >         $query \\
-    >         $cigar_paf \\
-    >         $set_cigar_bam \\
-    >         $bam_output
-    > 
+    >     samtools \\
+    >         faidx \\
+    >         $fasta \\
+    >         $args
     > 
     >     cat <<-END_VERSIONS > versions.yml
     >     "${task.process}":
-    >         minimap2: \$(minimap2 --version 2>&1)
     >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
     >     END_VERSIONS
     >     """
     >  
-    >   fb7bfb4268792db810e6f93de6045e1b [java.lang.String] quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:3161f532a5ea6f1dec9be5667c9efc2afdac6104-0 
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   5d4b4312c0f9bce3dde0445bff2b3280 [java.lang.String] fai 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
+    > 
+    > [ALIGN_LONGREADS:MINIMAP2_ALIGN_GPU (1)] cache hash: bd5d4cdb9cfdf1c19b2f8af0734edaa7; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
+    >   f64071fe4ce6d7b009f53015feae8ade [java.lang.String] ALIGN_LONGREADS:MINIMAP2_ALIGN_GPU 
+    >   5e82acb8ba6455137cdf2cd2a81eeb09 [java.lang.String]     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+    >         error("Parabricks module does not support Conda. Please use Docker / Singularity / Podman instead.")
+    >     }
+    >     def args   = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     def in_command = ""
+    >     if (reads.name.matches(".*\\.(fastq|fq)(\\.gz)?\$")) {
+    >         in_command = "--in-fq ${reads}"
+    >     }
+    >     else if (reads.name.endsWith('.bam')) {
+    >         in_command = "--in-bam ${reads}"
+    >     }
+    >     else {
+    >         error("Unsupported input file format: ${reads.name}. Supported formats: fastq, fastq.gz, fq, fq.gz, bam")
+    >     }
+    >     def extension = "${output_fmt}"
+    >     def index_command = index ? "--index ${index}" : ""
+    >     def known_sites_command    = known_sites ? (known_sites instanceof List ? known_sites.collect { knownSite -> "--knownSites ${knownSite}" }.join(' ') : "--knownSites ${known_sites}") : ""
+    >     def known_sites_output_cmd = known_sites ? "--out-recal-file ${prefix}.table" : ""
+    >     def intervals_command  = intervals     ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
+    >     def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    >     """
+    >     pbrun \\
+    >         minimap2 \\
+    >         --ref ${fasta} \\
+    >         ${in_command} \\
+    >         --out-bam ${prefix}.${extension} \\
+    >         ${index_command} \\
+    >         ${known_sites_command} \\
+    >         ${known_sites_output_cmd} \\
+    >         ${intervals_command} \\
+    >         ${num_gpus} \\
+    >         ${args}
+    >     """
+    >  
+    >   e894683567debc1eff42d8cf38fab72d [java.lang.String] nvcr.io/nvidia/clara/clara-parabricks:4.6.0-1 
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   553096c532e666fb42214fdf0520fe4a [java.lang.String] reads 
-    >   fcd1c71adb77600bd10a213700e2a51f [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/bc/6b6e27f642bf3c1117aa944babf940/test_1.fastq.gz, stageName:test_1.fastq.gz, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz)] 
+    >   fcd1c71adb77600bd10a213700e2a51f [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/13/e36d33d48e06d8a3a2401cd41e3bb5/test_1.fastq.gz, stageName:test_1.fastq.gz, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/illumina/fastq/test_1.fastq.gz)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
-    >   fec83c41a7c57f821d28e6b995ac3b35 [java.lang.String] reference 
-    >   be0ba66161bae7cf11972a73c8e9572f [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi, stageName:genome.mmi, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/90/e63d05fe6000fcb0bb31d1809e11f6/genome.mmi)] 
-    >   ccf1f8711aa211801cb5ed01bb124b46 [java.lang.String] bam_format 
-    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   402650ce03fd207c926dd4b70f4b2134 [java.lang.String] bam_index_extension 
-    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
-    >   3fb18579fe9f1742c9ae616db7578057 [java.lang.String] cigar_paf_format 
-    >   00000000000000000000000000000000 [java.lang.String]  
-    >   a6a266995496c3a378cf6f5a77149c72 [java.lang.String] cigar_bam 
-    >   00000000000000000000000000000000 [java.lang.String]  
+    >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   1948639f984981cfc51dfe462c11ba82 [java.lang.String] meta3 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   105e03d70ef5c389e573ff1c323ba2e5 [java.lang.String] index 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   fe45664e287ff11395639b6bed60763b [java.lang.String] meta4 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   1a6635f29e37273daf74863ce927530d [java.lang.String] intervals 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   f17d60c6ede00934953ddcb3ee555229 [java.lang.String] meta5 
+    >   00000000000000000000000000000000 [java.util.ArrayList] [] 
+    >   e095e71d71e5d85a31770592551e350e [java.lang.String] known_sites 
+    >   d618a97df21bbd4bb61c79cdeca965b4 [nextflow.util.ArrayBag] [] 
+    >   ec337161d6146744dd108b53d48dcd7f [java.lang.String] output_fmt 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   65ccae5e10ea815eb0beb62fe94e8c4e [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.args3=null, task.ext.args4=null, task.ext.args2=null, task.ext.prefix=null] 
+    >   6793eb8c58cdc73e27a8de7b307a8529 [java.lang.String] eval_outputs 
+    >   fd3c712c2ecbed4d91e9efa976531c21 [java.lang.String] nxf_out_eval_1=pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//' 
+    >   88824907a8692af42da51ef0c7d790e2 [java.util.HashMap$EntrySet] [task.ext.args=null, workflow.profile=debug,test,docker,gpu, task.ext.prefix=null] 
     > 
-    > [04/60155a] Submitted process > ALIGN_LONGREADS:MINIMAP2_ALIGN (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (1)] cache hash: b708f26236f137f7c402d2a847ce0fe2; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [8c/7a204d] Submitted process > SAMTOOLS_FAIDX (genome.fasta)
+    > [f3/9ab16e] Submitted process > ALIGN_LONGREADS:MINIMAP2_ALIGN_GPU (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (1)] cache hash: 91022220d2daeeffec3d5841b8768f14; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   19597c784cc32a26ec7276b94c681d03 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT 
     >   8a12e0d8fd605821210f2df15089a5d8 [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -250,18 +261,18 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   37925e00c2c867a364e7fa1d52ae9bfd [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam, stageName:test_fastq.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/04/60155a0b8c6cb7f06a25d525c93e7f/test_fastq.bam)] 
+    >   bf458c01943d5def2741784f6bf73a15 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/f3/9ab16e06895a09ca180a9343c54fe2/test_fastq.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/f3/9ab16e06895a09ca180a9343c54fe2/test_fastq.bam, stageName:test_fastq.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/f3/9ab16e06895a09ca180a9343c54fe2/test_fastq.bam)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
     >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   4dccca5e99f704ee07fa6381a6d3970c [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=wacky] 
+    >   b1a48bec4a3065e9143298f4e3bfe215 [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=my_test] 
     > 
-    > [ae/28c236] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (1)] cache hash: 3cf0045b390965e1b403b76d0b327459; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [b7/a2ad5d] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_SORT (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (1)] cache hash: 8d92d5804da1dd284d38480c1859e845; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   1dbe8482c60cf28c6f1fff9bddad7be9 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX 
     >   5b95d9cf4a85564d79fcd6e37614402a [java.lang.String]     def args = task.ext.args ?: ''
     >     """
@@ -281,14 +292,14 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
-    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   31f3aff34037d02954104117980da62e [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
     > 
-    > [a4/a4ab7c] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: c00f64b046b26be7a8ef9b0cfaa38910; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [05/0a2e3e] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:SAMTOOLS_INDEX (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: 8c9769acd00b7c61ae26730fb97367a0; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   19c70dc0acb85da0849ad9e9b359324c [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS 
     >   7fd9f9a46edf86abe81cb84b1dac8efe [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -309,44 +320,15 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   31f3aff34037d02954104117980da62e [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam)] 
     >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
-    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   6f14ea451e513d8f7064a4d4cc7dc42d [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
     > 
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: 4f5be177c546a62dc03e56f4906ad937; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
-    >   a8b78c9b89b8369ff378e1391d48acd3 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
-    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
-    >     def prefix = task.ext.prefix ?: "${meta.id}"
-    >     """
-    >     samtools \\
-    >         flagstat \\
-    >         --threads ${task.cpus} \\
-    >         $bam \\
-    >         > ${prefix}.flagstat
-    > 
-    >     cat <<-END_VERSIONS > versions.yml
-    >     "${task.process}":
-    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    >     END_VERSIONS
-    >     """
-    >  
-    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
-    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
-    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
-    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
-    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
-    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
-    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
-    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
-    > 
-    > [ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (1)] cache hash: 86ba2208adba45372b1e8b0e705a0ea7; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (1)] cache hash: 1da8397566b97826630b1efe6006fab7; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   8d5689acd6ac69486a8a5111828e8d76 [java.lang.String] ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED 
     >   9fec9060a5e33920153548a33177c01a [java.lang.String]     def args = task.ext.args ?: ''
     >     def args2 = task.ext.args2 ?: ''
@@ -381,9 +363,9 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
-    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   31f3aff34037d02954104117980da62e [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam)] 
     >   105e03d70ef5c389e573ff1c323ba2e5 [java.lang.String] index 
-    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   6f14ea451e513d8f7064a4d4cc7dc42d [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai)] 
     >   c187e49e2c9ca85c0cb9ee223c78ba6b [java.lang.String] regions 
     >   3ff3e3f046770a9decf4860d590e6a5a [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/assets/dummy_file.txt, storePath:/home/gburnett/scnanoseq/assets/dummy_file.txt, stageName:dummy_file.txt, sourcePath:/home/gburnett/scnanoseq/assets/dummy_file.txt)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
@@ -396,11 +378,40 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   2d55a1346381340a801aeecc91d4cf47 [java.util.HashMap$EntrySet] [task.ext.args=-b -F 4, task.ext.args2=null, task.ext.prefix=test_fastq.mapped_only] 
     > 
-    > [7d/47ec23] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
-    > [cd/8b0034] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
-    > [b1/49c493] Submitted process > ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: f40526340ca4d2ff96042e73573ffe0c; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: 56df128e367cd561574cec678f76caf5; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
+    >   a8b78c9b89b8369ff378e1391d48acd3 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
+    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         flagstat \\
+    >         --threads ${task.cpus} \\
+    >         $bam \\
+    >         > ${prefix}.flagstat
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   31f3aff34037d02954104117980da62e [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   6f14ea451e513d8f7064a4d4cc7dc42d [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [2d/85d668] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
+    > [2c/54be95] Submitted process > ALIGN_LONGREADS:SAMTOOLS_FILTER_MAPPED (test_fastq)
+    > [47/4923c3] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: 849b0688df68f2c9b9f6d6449ab4aa4f; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   f9d654fd115b60d466dabc9b2d9abe24 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS 
     >   07db10f64f92ff5b77c8bf2cb0d8f4d3 [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -423,20 +434,20 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
-    >   a0018e685da7de6231db2bc6bd608700 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ae/28c2361e439f6b67bc7373c8799372/wacky.bam)] 
+    >   31f3aff34037d02954104117980da62e [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/b7/a2ad5d13df27d60c5fd349cbd68374/my_test.bam)] 
     >   f792a6941a7c8fee95aa4475972a289a [java.lang.String] input_index 
-    >   ffe4a32e784c22b5606c0a55ab6c4d00 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/a4/a4ab7c808edb08ff9971b5edcdd184/wacky.bam.bai)] 
+    >   6f14ea451e513d8f7064a4d4cc7dc42d [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/05/0a2e3ed6eb97a15da5f94da7c4a443/my_test.bam.bai)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
     >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
     > 
-    > [60/2984df] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (1)] cache hash: 16cf5ff6ccc3f931526fadc320265b0e; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [ef/c80427] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (1)] cache hash: 2f1957715055484ef705cb8647549057; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   9cd3f28b6559f14af3b7ef3cb63f560b [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT 
     >   8a12e0d8fd605821210f2df15089a5d8 [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -468,18 +479,18 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   2b8b3eb344c845d87bae23130a1eb8ed [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam, stageName:test_fastq.mapped_only.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/b1/49c4935fae689cae0252a2ab6e12b8/test_fastq.mapped_only.bam)] 
+    >   7171f9f265bac46386f720c4f0c96c1c [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/2c/54be95d6f0b8583e1d409d1e56caac/test_fastq.mapped_only.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/2c/54be95d6f0b8583e1d409d1e56caac/test_fastq.mapped_only.bam, stageName:test_fastq.mapped_only.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/2c/54be95d6f0b8583e1d409d1e56caac/test_fastq.mapped_only.bam)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
     >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   4dccca5e99f704ee07fa6381a6d3970c [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=wacky] 
+    >   b1a48bec4a3065e9143298f4e3bfe215 [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=my_test] 
     > 
-    > [5a/f6c5ef] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (1)] cache hash: e46f3c402f7a11d8aa10d31ebd972a2f; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [8a/376c65] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_SORT (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (1)] cache hash: b7d7f8b08eb68e148ee1e514506f8d95; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   c2141a6b0bbb3d6a91c365c4e35915f9 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX 
     >   5b95d9cf4a85564d79fcd6e37614402a [java.lang.String]     def args = task.ext.args ?: ''
     >     """
@@ -499,43 +510,14 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
-    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   40fd1b5076a809bdb97ee9864b67ac1b [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   eab359affdb9334848cc02803d7db724 [java.util.HashMap$EntrySet] [task.ext.args=null] 
     > 
-    > [ab/389095] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: 667a8b7848ceda6b47380a77e7164710; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
-    >   ae1edbc966f96699047514860364f009 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
-    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
-    >     def prefix = task.ext.prefix ?: "${meta.id}"
-    >     """
-    >     samtools \\
-    >         flagstat \\
-    >         --threads ${task.cpus} \\
-    >         $bam \\
-    >         > ${prefix}.flagstat
-    > 
-    >     cat <<-END_VERSIONS > versions.yml
-    >     "${task.process}":
-    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    >     END_VERSIONS
-    >     """
-    >  
-    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
-    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
-    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
-    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
-    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
-    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
-    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
-    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
-    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
-    > 
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: 4ae1676fee08b23f8355389c69a26c44; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [1e/c773dd] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:SAMTOOLS_INDEX (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (1)] cache hash: cf97454db849986d7e4efd75077ee8f7; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   7a314d556faf59f8cfe741e410e44c94 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS 
     >   7fd9f9a46edf86abe81cb84b1dac8efe [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -556,17 +538,46 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
-    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   40fd1b5076a809bdb97ee9864b67ac1b [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam)] 
     >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
-    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
+    >   e5004d2964c9e88db0a41d07827ab0dd [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
     > 
-    > [32/6038ae] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
-    > [69/82aa9e] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
-    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: f2049fe5fbbcc14cec794c601758bf6e; mode: STANDARD; entries: 
-    >   18123f40af3de93f8bd2613be6dd7475 [java.util.UUID] 864bb55b-5076-4602-be17-58f85f8caaf2 
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (1)] cache hash: e0d2697a4966792d8cacb3e4fe5165be; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
+    >   ae1edbc966f96699047514860364f009 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT 
+    >   76101650d02d30ac0954a2fe23117838 [java.lang.String]     def args = task.ext.args ?: ''
+    >     def prefix = task.ext.prefix ?: "${meta.id}"
+    >     """
+    >     samtools \\
+    >         flagstat \\
+    >         --threads ${task.cpus} \\
+    >         $bam \\
+    >         > ${prefix}.flagstat
+    > 
+    >     cat <<-END_VERSIONS > versions.yml
+    >     "${task.process}":
+    >         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    >     END_VERSIONS
+    >     """
+    >  
+    >   fcf3d564d2128101066dfe3bd9f560a1 [java.lang.String] quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0 
+    >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
+    >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
+    >   05a6e9bc5229dd6139c2abea6473b29f [java.lang.String] bam 
+    >   40fd1b5076a809bdb97ee9864b67ac1b [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam)] 
+    >   797d0098c78c00370bc4beb28e15f7e4 [java.lang.String] bai 
+    >   e5004d2964c9e88db0a41d07827ab0dd [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai)] 
+    >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
+    >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
+    >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
+    > 
+    > [25/0c6d7d] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_IDXSTATS (test_fastq)
+    > [b0/c40bba] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_FLAGSTAT (test_fastq)
+    > [ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (1)] cache hash: 3c2f8901ba4889d3243728339e6f97c4; mode: STANDARD; entries: 
+    >   8d2de3e0a04a9336fa6a3d8ba2acaef7 [java.util.UUID] 11f98bcd-4d85-4bc3-a118-80199faaebca 
     >   4a3ec838ac78469de18ab9b0200dc189 [java.lang.String] ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS 
     >   07db10f64f92ff5b77c8bf2cb0d8f4d3 [java.lang.String]     def args = task.ext.args ?: ''
     >     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -589,26 +600,26 @@ Warning: every snapshot that fails during this test run is re-recorded.
     >   22a9e5e0e97f0475e310f04c56b1393a [java.lang.String] meta 
     >   cd3fa9a0f0ea989151a8d5ce002fb14f [java.util.LinkedHashMap] [id:test_fastq, single_end:true] 
     >   118323febdfe82be70d7ac6c1592e35d [java.lang.String] input 
-    >   1277fe17dd26561ac6cff90cc8ab2b76 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam, stageName:wacky.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/5a/f6c5efc6cae5cda1d1956bef5d9049/wacky.bam)] 
+    >   40fd1b5076a809bdb97ee9864b67ac1b [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam, stageName:my_test.bam, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/8a/376c651482ec3cb29d45d5aeb2bbaa/my_test.bam)] 
     >   f792a6941a7c8fee95aa4475972a289a [java.lang.String] input_index 
-    >   49f17ddb9e69e7c31d6856824c8c47a0 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai, stageName:wacky.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/ab/38909568dfdc7ddb07e8f008974b3d/wacky.bam.bai)] 
+    >   e5004d2964c9e88db0a41d07827ab0dd [nextflow.util.ArrayBag] [FileHolder(sourceObj:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai, stageName:my_test.bam.bai, sourcePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/1e/c773dda0b42500399bc6d2b98557c7/my_test.bam.bai)] 
     >   409b6322c96c5aed2e508e57cc521d5d [java.lang.String] meta2 
     >   09ab564bac19fbb0a2fb7502b3e9d8e5 [java.util.LinkedHashMap] [id:test_fasta] 
     >   73a5ce311a22d83f9cdf7b743bde6695 [java.lang.String] fasta 
-    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/f3466bccbc2e174daabd0609ed7ea661/work/stage-864bb55b-5076-4602-be17-58f85f8caaf2/35/0faa9e973d435b64127ab3b3153922/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
+    >   d2a7e7979504cd1f2ef6025970089b25 [nextflow.util.ArrayBag] [FileHolder(sourceObj:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta, storePath:/home/gburnett/scnanoseq/.nf-test/tests/d7ceecebe6e1d32045c871b5bf3679c6/work/stage-11f98bcd-4d85-4bc3-a118-80199faaebca/82/c553328c5daacb7bd8340b0cc41f98/genome.fasta, stageName:genome.fasta, sourcePath:/ngi-igenomes/testdata/nf-core/modules/genomics/sarscov2/genome/genome.fasta)] 
     >   4f9d4b0d22865056c37fb6d9c2a04a67 [java.lang.String] $ 
     >   16fe7483905cce7a85670e43e4678877 [java.lang.Boolean] true 
     >   f38e981944e372f17682bf00a33a53cc [java.util.HashMap$EntrySet] [task.ext.args=null, task.ext.prefix=null] 
     > 
-    > [3e/0b13dd] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
-    [32mPASSED[0m (29.199s)
+    > [a5/672965] Submitted process > ALIGN_LONGREADS:BAM_SORT_STATS_SAMTOOLS_FILTERED:BAM_STATS_SAMTOOLS:SAMTOOLS_STATS (test_fastq)
+    [32mPASSED[0m (46.393s)
   Snapshots:
-    1 created [align_longreads - default params]
+    1 created [align_longreads - gpu params]
     Obsolete snapshots can only be checked if all tests of a file are executed successful.
 
 
 Snapshot Summary:
   1 created
 
-[1m[32mSUCCESS: [0m[0mExecuted 1 tests in 29.211s
+[1m[32mSUCCESS: [0m[0mExecuted 1 tests in 46.417s
 

--- a/modules.json
+++ b/modules.json
@@ -58,6 +58,11 @@
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/nanoplot/nanoplot.diff"
                     },
+                    "parabricks/minimap2": {
+                        "branch": "master",
+                        "git_sha": "f0b0dc3c3f001b1b7bf814a3c353baecbab17ea1",
+                        "installed_by": ["modules"]
+                    },
                     "picard/markduplicates": {
                         "branch": "master",
                         "git_sha": "49f4e50534fe4b64101e62ea41d5dc43b1324358",

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -1,0 +1,102 @@
+process PARABRICKS_MINIMAP2 {
+    tag "${meta.id}"
+    label 'process_high'
+    label 'process_gpu'
+    // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
+    stageInMode 'copy'
+
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.6.0-1"
+
+    input:
+    tuple val(meta),  path(reads)
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(intervals)
+    tuple val(meta4), path(known_sites)
+    val output_fmt
+
+    output:
+    tuple val(meta), path("*.bam"),                   emit: bam,                 optional: true
+    tuple val(meta), path("*.bai"),                   emit: bai,                 optional: true
+    tuple val(meta), path("*.cram"),                  emit: cram,                optional: true
+    tuple val(meta), path("*.crai"),                  emit: crai,                optional: true
+    tuple val(meta), path("*.table"),                 emit: bqsr_table,          optional: true
+    tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
+    tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true
+    path "compatible_versions.yml",                   emit: compatible_versions, optional: true
+    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions_parabricks
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error("Parabricks module does not support Conda. Please use Docker / Singularity / Podman instead.")
+    }
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    // Determine input format and set appropriate command flag
+    def in_command = ""
+    if (reads.name.matches(".*\\.(fastq|fq)(\\.gz)?\$")) {
+        in_command = "--in-fq ${reads}"
+    }
+    else if (reads.name.endsWith('.bam')) {
+        in_command = "--in-bam ${reads}"
+    }
+    else {
+        error("Unsupported input file format: ${reads.name}. Supported formats: fastq, fastq.gz, fq, fq.gz, bam")
+    }
+    def extension = "${output_fmt}"
+
+    def known_sites_command    = known_sites ? (known_sites instanceof List ? known_sites.collect { knownSite -> "--knownSites ${knownSite}" }.join(' ') : "--knownSites ${known_sites}") : ""
+    def known_sites_output_cmd = known_sites ? "--out-recal-file ${prefix}.table" : ""
+    def intervals_command  = intervals     ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
+
+    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    """
+    pbrun \\
+        minimap2 \\
+        --ref ${fasta} \\
+        ${in_command} \\
+        --out-bam ${prefix}.${extension} \\
+        ${known_sites_command} \\
+        ${known_sites_output_cmd} \\
+        ${intervals_command} \\
+        ${num_gpus} \\
+        ${args}
+    """
+
+    stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error("Parabricks module does not support Conda. Please use Docker / Singularity / Podman instead.")
+    }
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension       = "${output_fmt}"
+    def extension_index = "${output_fmt}" == "cram" ? "crai" : "bai"
+    def known_sites_output       = known_sites ? "touch ${prefix}.table" : ""
+    def qc_metrics_output        = args.contains("--out-qc-metrics-dir") ? "mkdir ${prefix}_qc_metrics" : ""
+    def duplicate_metrics_output = args.contains("--out-duplicate-metrics") ? "touch ${prefix}.duplicate-metrics.txt" : ""
+    """
+    touch ${prefix}.${extension}
+    touch ${prefix}.${extension}.${extension_index}
+    ${known_sites_output}
+    ${qc_metrics_output}
+    ${duplicate_metrics_output}
+
+    # Capture the full version output once and store it in a variable
+    pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
+
+    # We handle this different to the other modules because minimap does not begin with an Uppercase letter
+
+    # Generate compatible_versions.yml
+    cat <<EOF > compatible_versions.yml
+    "${task.process}":
+        pbrun_version: \$(echo "\$pbrun_version_output" | grep "pbrun:" | awk '{print \$2}')
+        compatible_with:
+        \$(echo "\$pbrun_version_output" | tr '\\t' ' ' | awk -F':' '/Compatible With:/,/^---/ { if (\$0 !~ /Compatible With:/ && \$0 !~ /^---\$/ && index(\$0,":")>0) { key=\$1; val=\$2; gsub(/^[ ]+|[ ]+\$/, "", key); gsub(/^[ ]+|[ ]+\$/, "", val); printf "  %s: %s\\n", key, val } }')
+    EOF
+    """
+}

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -10,15 +10,14 @@ process PARABRICKS_MINIMAP2 {
     input:
     tuple val(meta),  path(reads)
     tuple val(meta2), path(fasta)
-    tuple val(meta3), path(intervals)
-    tuple val(meta4), path(known_sites)
+    tuple val(meta3), path(index)
+    tuple val(meta4), path(intervals)
+    tuple val(meta5), path(known_sites)
     val output_fmt
 
     output:
-    tuple val(meta), path("*.bam"),                   emit: bam,                 optional: true
-    tuple val(meta), path("*.bai"),                   emit: bai,                 optional: true
-    tuple val(meta), path("*.cram"),                  emit: cram,                optional: true
-    tuple val(meta), path("*.crai"),                  emit: crai,                optional: true
+    tuple val(meta), path("*.{bam,cram}"),            emit: bam,                 optional: true
+    tuple val(meta), path("*.{bai,crai}"),            emit: index,               optional: true
     tuple val(meta), path("*.table"),                 emit: bqsr_table,          optional: true
     tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
     tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -21,7 +21,8 @@ process PARABRICKS_MINIMAP2 {
     tuple val(meta), path("*.table"),                 emit: bqsr_table,          optional: true
     tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
     tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true
-    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions_parabricks
+    path "compatible_versions.yml",                   emit: compatible_versions, optional: true
+    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -85,5 +86,17 @@ process PARABRICKS_MINIMAP2 {
     ${known_sites_output}
     ${qc_metrics_output}
     ${duplicate_metrics_output}
+    # Capture the full version output once and store it in a variable
+    pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
+
+    # We handle this different to the other modules because minimap does not begin with an Uppercase letter
+
+    # Generate compatible_versions.yml
+    cat <<EOF > compatible_versions.yml
+    "${task.process}":
+        pbrun_version: \$(echo "\$pbrun_version_output" | grep "pbrun:" | awk '{print \$2}')
+        compatible_with:
+        \$(echo "\$pbrun_version_output" | tr '\\t' ' ' | awk -F':' '/Compatible With:/,/^---/ { if (\$0 !~ /Compatible With:/ && \$0 !~ /^---\$/ && index(\$0,":")>0) { key=\$1; val=\$2; gsub(/^[ ]+|[ ]+\$/, "", key); gsub(/^[ ]+|[ ]+\$/, "", val); printf "  %s: %s\\n", key, val } }')
+    EOF
     """
 }

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -22,7 +22,7 @@ process PARABRICKS_MINIMAP2 {
     tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
     tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true
     path "compatible_versions.yml",                   emit: compatible_versions, optional: true
-    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions
+    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions_parabricks
 
     when:
     task.ext.when == null || task.ext.when
@@ -66,7 +66,7 @@ process PARABRICKS_MINIMAP2 {
         ${intervals_command} \\
         ${num_gpus} \\
         ${args}
-    
+
     # Capture the full version output once and store it in a variable
     pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
 

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -21,7 +21,6 @@ process PARABRICKS_MINIMAP2 {
     tuple val(meta), path("*.table"),                 emit: bqsr_table,          optional: true
     tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
     tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true
-    path "compatible_versions.yml",                   emit: compatible_versions, optional: true
     tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions_parabricks
 
     when:
@@ -48,6 +47,7 @@ process PARABRICKS_MINIMAP2 {
     }
     def extension = "${output_fmt}"
 
+    def index_command = index ? "--index ${index}" : ""
     def known_sites_command    = known_sites ? (known_sites instanceof List ? known_sites.collect { knownSite -> "--knownSites ${knownSite}" }.join(' ') : "--knownSites ${known_sites}") : ""
     def known_sites_output_cmd = known_sites ? "--out-recal-file ${prefix}.table" : ""
     def intervals_command  = intervals     ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
@@ -59,6 +59,7 @@ process PARABRICKS_MINIMAP2 {
         --ref ${fasta} \\
         ${in_command} \\
         --out-bam ${prefix}.${extension} \\
+        ${index_command} \\
         ${known_sites_command} \\
         ${known_sites_output_cmd} \\
         ${intervals_command} \\
@@ -84,18 +85,5 @@ process PARABRICKS_MINIMAP2 {
     ${known_sites_output}
     ${qc_metrics_output}
     ${duplicate_metrics_output}
-
-    # Capture the full version output once and store it in a variable
-    pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
-
-    # We handle this different to the other modules because minimap does not begin with an Uppercase letter
-
-    # Generate compatible_versions.yml
-    cat <<EOF > compatible_versions.yml
-    "${task.process}":
-        pbrun_version: \$(echo "\$pbrun_version_output" | grep "pbrun:" | awk '{print \$2}')
-        compatible_with:
-        \$(echo "\$pbrun_version_output" | tr '\\t' ' ' | awk -F':' '/Compatible With:/,/^---/ { if (\$0 !~ /Compatible With:/ && \$0 !~ /^---\$/ && index(\$0,":")>0) { key=\$1; val=\$2; gsub(/^[ ]+|[ ]+\$/, "", key); gsub(/^[ ]+|[ ]+\$/, "", val); printf "  %s: %s\\n", key, val } }')
-    EOF
     """
 }

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -21,7 +21,8 @@ process PARABRICKS_MINIMAP2 {
     tuple val(meta), path("*.table"),                 emit: bqsr_table,          optional: true
     tuple val(meta), path("*_qc_metrics"),            emit: qc_metrics,          optional: true
     tuple val(meta), path("*.duplicate-metrics.txt"), emit: duplicate_metrics,   optional: true
-    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions_parabricks
+    path "compatible_versions.yml",                   emit: compatible_versions, optional: true
+    tuple val("${task.process}"), val('parabricks'), eval("pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'"), topic: versions, emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -65,6 +66,19 @@ process PARABRICKS_MINIMAP2 {
         ${intervals_command} \\
         ${num_gpus} \\
         ${args}
+    
+    # Capture the full version output once and store it in a variable
+    pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
+
+    # We handle this different to the other modules because minimap does not begin with an Uppercase letter
+
+    # Generate compatible_versions.yml
+    cat <<EOF > compatible_versions.yml
+    "${task.process}":
+        pbrun_version: \$(echo "\$pbrun_version_output" | grep "pbrun:" | awk '{print \$2}')
+        compatible_with:
+        \$(echo "\$pbrun_version_output" | tr '\\t' ' ' | awk -F':' '/Compatible With:/,/^---/ { if (\$0 !~ /Compatible With:/ && \$0 !~ /^---\$/ && index(\$0,":")>0) { key=\$1; val=\$2; gsub(/^[ ]+|[ ]+\$/, "", key); gsub(/^[ ]+|[ ]+\$/, "", val); printf "  %s: %s\\n", key, val } }')
+    EOF
     """
 
     stub:
@@ -85,5 +99,17 @@ process PARABRICKS_MINIMAP2 {
     ${known_sites_output}
     ${qc_metrics_output}
     ${duplicate_metrics_output}
+    # Capture the full version output once and store it in a variable
+    pbrun_version_output=\$(pbrun minimap2 --version 2>&1)
+
+    # We handle this different to the other modules because minimap does not begin with an Uppercase letter
+
+    # Generate compatible_versions.yml
+    cat <<EOF > compatible_versions.yml
+    "${task.process}":
+        pbrun_version: \$(echo "\$pbrun_version_output" | grep "pbrun:" | awk '{print \$2}')
+        compatible_with:
+        \$(echo "\$pbrun_version_output" | tr '\\t' ' ' | awk -F':' '/Compatible With:/,/^---/ { if (\$0 !~ /Compatible With:/ && \$0 !~ /^---\$/ && index(\$0,":")>0) { key=\$1; val=\$2; gsub(/^[ ]+|[ ]+\$/, "", key); gsub(/^[ ]+|[ ]+\$/, "", val); printf "  %s: %s\\n", key, val } }')
+    EOF
     """
 }

--- a/modules/nf-core/parabricks/minimap2/meta.yml
+++ b/modules/nf-core/parabricks/minimap2/meta.yml
@@ -1,0 +1,180 @@
+name: "parabricks_minimap2"
+description: NVIDIA Clara Parabricks GPU-accelerated minimap2 for aligning long read
+  sequences against a large reference database using an accelerated KSW2 to convert
+  FASTQ to BAM/CRAM.
+keywords:
+  - align
+  - sort
+  - bqsr
+  - duplicates
+  - long read
+tools:
+  - "parabricks":
+      description: "NVIDIA Clara Parabricks GPU-accelerated genomics tools"
+      homepage: "https://www.nvidia.com/en-us/clara/genomics/"
+      documentation: "https://docs.nvidia.com/clara/parabricks/latest/index.html"
+      licence: ["custom"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: Input read file, supported formats - 'fastq', 'fastq.gz', 'fq',
+          'fq.gz', 'bam'
+        pattern: "^.*\\.(fastq|fastq\\.gz|fq|fq\\.gz|bam)$"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_3989" # GZIP
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing fasta information
+    - fasta:
+        type: file
+        description: reference fasta file - must be unzipped
+        pattern: "*.fasta"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing index information
+    - intervals:
+        type: file
+        description: (optional) file(s) containing genomic intervals for use in base
+          quality score recalibration (BQSR)
+        pattern: "*.{bed,interval_list,picard,list,intervals}"
+        ontologies: []
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing known sites information
+    - known_sites:
+        type: file
+        description: (optional) known sites file(s) for calculating BQSR. markdups must
+          be true to perform BQSR.
+        pattern: "*.vcf.gz"
+        ontologies:
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3989" # GZIP
+  - output_fmt:
+      type: string
+      description: Output format for the alignment. Options are 'bam' or 'cram'
+      pattern: "{bam,cram}"
+output:
+  bam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bam":
+          type: file
+          description: Sorted BAM file
+          pattern: "*.bam"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  bai:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bai":
+          type: file
+          description: index corresponding to sorted BAM file
+          pattern: "*.bai"
+          ontologies: []
+  cram:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.cram":
+          type: file
+          description: Sorted CRAM file
+          pattern: "*.cram"
+          ontologies: []
+  crai:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.crai":
+          type: file
+          description: index corresponding to sorted CRAM file
+          pattern: "*.crai"
+          ontologies: []
+  bqsr_table:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.table":
+          type: file
+          description: (optional) table from base quality score recalibration calculation,
+            to be used with parabricks/applybqsr
+          pattern: "*.table"
+          ontologies: []
+  qc_metrics:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*_qc_metrics":
+          type: directory
+          description: (optional) optional directory of qc metrics
+          pattern: "*_qc_metrics"
+  duplicate_metrics:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.duplicate-metrics.txt":
+          type: file
+          description: (optional) metrics calculated from marking duplicates in the
+            bam file
+          pattern: "*.duplicate-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # TXT
+  compatible_versions:
+    - compatible_versions.yml:
+        type: file
+        description: File containing info on compatible CPU-based software versions.
+        pattern: "compatible_versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+  versions_parabricks:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - parabricks:
+          type: string
+          description: The tool name
+      - "pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'":
+          type: string
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - parabricks:
+          type: string
+          description: The tool name
+      - "pbrun version | grep -m1 '^pbrun:' | sed 's/^pbrun:[[:space:]]*//'":
+          type: string
+          description: The command used to generate the version of the tool
+authors:
+  - "@haidyi"
+maintainers:
+  - "@haidyi"

--- a/modules/nf-core/parabricks/minimap2/meta.yml
+++ b/modules/nf-core/parabricks/minimap2/meta.yml
@@ -43,13 +43,22 @@ input:
         type: map
         description: |
           Groovy Map containing index information
+    - index:
+        type: file
+        description: (optional) minimap2 index file for the reference
+        pattern: "*.mmi"
+        ontologies: []
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing intervals information
     - intervals:
         type: file
         description: (optional) file(s) containing genomic intervals for use in base
           quality score recalibration (BQSR)
         pattern: "*.{bed,interval_list,picard,list,intervals}"
         ontologies: []
-  - - meta4:
+  - - meta5:
         type: map
         description: |
           Groovy Map containing known sites information
@@ -72,44 +81,22 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.bam":
+      - "*.{bam,cram}":
           type: file
-          description: Sorted BAM file
-          pattern: "*.bam"
+          description: Sorted BAM or CRAM file
+          pattern: "*.{bam,cram}"
           ontologies:
             - edam: "http://edamontology.org/format_2572" # BAM
-  bai:
+  index:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.bai":
+      - "*.{bai,crai}":
           type: file
-          description: index corresponding to sorted BAM file
-          pattern: "*.bai"
-          ontologies: []
-  cram:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - "*.cram":
-          type: file
-          description: Sorted CRAM file
-          pattern: "*.cram"
-          ontologies: []
-  crai:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - "*.crai":
-          type: file
-          description: index corresponding to sorted CRAM file
-          pattern: "*.crai"
+          description: Index corresponding to sorted BAM or CRAM file
+          pattern: "*.{bai,crai}"
           ontologies: []
   bqsr_table:
     - - meta:
@@ -178,3 +165,4 @@ authors:
   - "@haidyi"
 maintainers:
   - "@haidyi"
+  - "@gburnett-nvidia"

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test
@@ -1,0 +1,538 @@
+nextflow_process {
+
+    name "Test Process PARABRICKS_MINIMAP2"
+    script "../main.nf"
+    process "PARABRICKS_MINIMAP2"
+
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "parabricks"
+    tag "parabricks/minimap2"
+    tag "gpu"
+
+    test("homo_sapiens - fastq - bam") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    file(process.out.bai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - fastq - bam - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out,
+                    path(process.out.compatible_versions.get(0)).yaml
+                    ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - fastq - bam - interval_file") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    file(process.out.bai[0][1]).name,
+                ).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - fastq - bam - interval_file - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - fastq - bam - knownsites") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
+                ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    file(process.out.bai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - fastq - bam - knownsites - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
+                ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - fastq - bam - interval_file - knownsites") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[3] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
+                ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    file(process.out.bai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - fastq - bam - interval_file - knownsites - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[3] = [
+                    [:],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
+                ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+
+    test("homo_sapiens - bam - bam") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test3.single_end.markduplicates.sorted.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    file(process.out.bai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - bam - bam - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test3.single_end.markduplicates.sorted.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'bam'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - fastq - cram") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'cram'
+                """
+            }
+        }
+
+        then {
+            def fasta = "https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/sarscov2/genome/genome.fasta"
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    cram(
+                        process.out.cram[0][1],
+                        fasta,
+                        ).getReadsMD5(),
+                    file(process.out.crai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - fastq - cram - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'cram'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - bam - cram") {
+
+        when {
+            params {
+                module_args = '--low-memory'
+                // Using --low-memory for testing
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test3.single_end.markduplicates.sorted.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'cram'
+                """
+            }
+        }
+
+        then {
+            def fasta = "https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/sarscov2/genome/genome.fasta"
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    cram(
+                        process.out.cram[0][1],
+                        fasta,
+                        ).getReadsMD5(),
+                    file(process.out.crai[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - bam - cram - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test3.single_end.markduplicates.sorted.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = 'cram'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test
@@ -31,7 +31,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -68,7 +69,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -101,12 +103,13 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
-                input[2] = [
+                input[2] = [ [], [] ]
+                input[3] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -141,12 +144,13 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
-                input[2] = [
+                input[2] = [ [], [] ]
+                input[3] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -178,11 +182,12 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
-                input[3] = [
+                input[3] = [ [], [] ]
+                input[4] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
                 ]
-                input[4] = 'bam'
+                input[5] = 'bam'
                 """
             }
         }
@@ -219,11 +224,12 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
-                input[3] = [
+                input[3] = [ [], [] ]
+                input[4] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
                 ]
-                input[4] = 'bam'
+                input[5] = 'bam'
                 """
             }
         }
@@ -254,15 +260,16 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
-                input[2] = [
+                input[2] = [ [], [] ]
+                input[3] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[3] = [
+                input[4] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
                 ]
-                input[4] = 'bam'
+                input[5] = 'bam'
                 """
             }
         }
@@ -298,15 +305,16 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
-                input[2] = [
+                input[2] = [ [], [] ]
+                input[3] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                 ]
-                input[3] = [
+                input[4] = [
                     [:],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/ngscheckmate/test1.vcf.gz', checkIfExists: true)
                 ]
-                input[4] = 'bam'
+                input[5] = 'bam'
                 """
             }
         }
@@ -339,7 +347,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -376,7 +385,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'bam'
+                input[4] = [ [], [] ]
+                input[5] = 'bam'
                 """
             }
         }
@@ -408,7 +418,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'cram'
+                input[4] = [ [], [] ]
+                input[5] = 'cram'
                 """
             }
         }
@@ -449,7 +460,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'cram'
+                input[4] = [ [], [] ]
+                input[5] = 'cram'
                 """
             }
         }
@@ -481,7 +493,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'cram'
+                input[4] = [ [], [] ]
+                input[5] = 'cram'
                 """
             }
         }
@@ -522,7 +535,8 @@ nextflow_process {
                 ]
                 input[2] = [ [], [] ]
                 input[3] = [ [], [] ]
-                input[4] = 'cram'
+                input[4] = [ [], [] ]
+                input[5] = 'cram'
                 """
             }
         }

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test
@@ -42,7 +42,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    file(process.out.bai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -119,7 +119,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    file(process.out.bai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                 ).match() }
             )
         }
@@ -197,7 +197,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    file(process.out.bai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -279,7 +279,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    file(process.out.bai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -358,7 +358,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    file(process.out.bai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -430,10 +430,10 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     cram(
-                        process.out.cram[0][1],
+                        process.out.bam[0][1],
                         fasta,
                         ).getReadsMD5(),
-                    file(process.out.crai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -505,10 +505,10 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     cram(
-                        process.out.cram[0][1],
+                        process.out.bam[0][1],
                         fasta,
                         ).getReadsMD5(),
-                    file(process.out.crai[0][1]).name,
+                    file(process.out.index[0][1]).name,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
@@ -1,0 +1,844 @@
+{
+    "homo_sapiens - fastq - cram": {
+        "content": [
+            "da777b5d079e09dfc076b1c89f93ef3e",
+            "test.cram.crai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:34:01.676029384"
+    },
+    "homo_sapiens - fastq - bam - knownsites": {
+        "content": [
+            "da777b5d079e09dfc076b1c89f93ef3e",
+            "test.bam.bai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:31:59.111593307"
+    },
+    "homo_sapiens - fastq - cram - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    
+                ],
+                "bam": [
+                    
+                ],
+                "bqsr_table": [
+                    
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cram": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:34:13.489438634"
+    },
+    "homo_sapiens - bam - cram": {
+        "content": [
+            "7de0e6c365b969e0b0ce277e4796ea45",
+            "test.cram.crai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:34:42.614345374"
+    },
+    "homo_sapiens - fastq - bam - interval_file - knownsites - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bqsr_table": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:32:49.974659902"
+    },
+    "homo_sapiens - bam - bam": {
+        "content": [
+            "7de0e6c365b969e0b0ce277e4796ea45",
+            "test.bam.bai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:33:20.518685108"
+    },
+    "homo_sapiens - fastq - bam - knownsites - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bqsr_table": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:32:09.966638852"
+    },
+    "homo_sapiens - fastq - bam - interval_file": {
+        "content": [
+            "da777b5d079e09dfc076b1c89f93ef3e",
+            "test.bam.bai"
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:31:19.122567375"
+    },
+    "homo_sapiens - fastq - bam": {
+        "content": [
+            "da777b5d079e09dfc076b1c89f93ef3e",
+            "test.bam.bai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:30:39.451852003"
+    },
+    "homo_sapiens - fastq - bam - interval_file - knownsites": {
+        "content": [
+            "da777b5d079e09dfc076b1c89f93ef3e",
+            "test.bam.bai",
+            {
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:32:38.630274922"
+    },
+    "homo_sapiens - bam - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bqsr_table": [
+                    
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:33:32.102263959"
+    },
+    "homo_sapiens - fastq - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bqsr_table": [
+                    
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            },
+            {
+                "PARABRICKS_MINIMAP2": {
+                    "pbrun_version": "4.6.0-1",
+                    "compatible_with": {
+                        "minimap2": 2.24
+                    }
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:30:50.547418555"
+    },
+    "homo_sapiens - bam - cram - stub": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    
+                ],
+                "bam": [
+                    
+                ],
+                "bqsr_table": [
+                    
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cram": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:34:53.848400581"
+    },
+    "homo_sapiens - fastq - bam - interval_file - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "8": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ],
+                "bai": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bqsr_table": [
+                    
+                ],
+                "compatible_versions": [
+                    "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "duplicate_metrics": [
+                    
+                ],
+                "qc_metrics": [
+                    
+                ],
+                "versions_parabricks": [
+                    [
+                        "PARABRICKS_MINIMAP2",
+                        "parabricks",
+                        "4.6.0-1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-21T13:31:30.016991953"
+    }
+}

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
@@ -43,12 +43,6 @@
         "content": [
             {
                 "0": [
-                    
-                ],
-                "1": [
-                    
-                ],
-                "2": [
                     [
                         {
                             "id": "test",
@@ -57,7 +51,7 @@
                         "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "3": [
+                "1": [
                     [
                         {
                             "id": "test",
@@ -66,30 +60,33 @@
                         "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
                 "4": [
                     
                 ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
                     ]
                 ],
-                "bai": [
-                    
-                ],
                 "bam": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "bqsr_table": [
                     
@@ -97,7 +94,10 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
+                "duplicate_metrics": [
+                    
+                ],
+                "index": [
                     [
                         {
                             "id": "test",
@@ -105,18 +105,6 @@
                         },
                         "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
-                ],
-                "cram": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "duplicate_metrics": [
-                    
                 ],
                 "qc_metrics": [
                     
@@ -132,9 +120,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:34:13.489438634"
+        "timestamp": "2026-03-12T08:49:26.763200957"
     },
     "homo_sapiens - bam - cram": {
         "content": [
@@ -178,12 +166,6 @@
                     ]
                 ],
                 "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
                     [
                         {
                             "id": "test",
@@ -192,29 +174,20 @@
                         "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
-                    ]
-                ],
-                "bai": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bam": [
@@ -238,14 +211,17 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
-                    
-                ],
-                "cram": [
-                    
-                ],
                 "duplicate_metrics": [
                     
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "qc_metrics": [
                     
@@ -261,9 +237,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:32:49.974659902"
+        "timestamp": "2026-03-12T08:48:19.89523659"
     },
     "homo_sapiens - bam - bam": {
         "content": [
@@ -307,12 +283,6 @@
                     ]
                 ],
                 "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
                     [
                         {
                             "id": "test",
@@ -321,29 +291,20 @@
                         "test.table:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
-                    ]
-                ],
-                "bai": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bam": [
@@ -367,14 +328,17 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
-                    
-                ],
-                "cram": [
-                    
-                ],
                 "duplicate_metrics": [
                     
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "qc_metrics": [
                     
@@ -390,9 +354,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:32:09.966638852"
+        "timestamp": "2026-03-12T08:47:44.770248707"
     },
     "homo_sapiens - fastq - bam - interval_file": {
         "content": [
@@ -476,28 +440,13 @@
                     
                 ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
-                    ]
-                ],
-                "bai": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bam": [
@@ -515,14 +464,17 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
-                    
-                ],
-                "cram": [
-                    
-                ],
                 "duplicate_metrics": [
                     
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "qc_metrics": [
                     
@@ -538,9 +490,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:33:32.102263959"
+        "timestamp": "2026-03-12T08:48:54.523688109"
     },
     "homo_sapiens - fastq - bam - stub": {
         "content": [
@@ -573,28 +525,13 @@
                     
                 ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
-                    ]
-                ],
-                "bai": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bam": [
@@ -612,14 +549,17 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
-                    
-                ],
-                "cram": [
-                    
-                ],
                 "duplicate_metrics": [
                     
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "qc_metrics": [
                     
@@ -643,20 +583,14 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:30:50.547418555"
+        "timestamp": "2026-03-12T08:45:33.262157843"
     },
     "homo_sapiens - bam - cram - stub": {
         "content": [
             {
                 "0": [
-                    
-                ],
-                "1": [
-                    
-                ],
-                "2": [
                     [
                         {
                             "id": "test",
@@ -665,7 +599,7 @@
                         "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "3": [
+                "1": [
                     [
                         {
                             "id": "test",
@@ -674,30 +608,33 @@
                         "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
                 "4": [
                     
                 ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
                     ]
                 ],
-                "bai": [
-                    
-                ],
                 "bam": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "bqsr_table": [
                     
@@ -705,7 +642,10 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
+                "duplicate_metrics": [
+                    
+                ],
+                "index": [
                     [
                         {
                             "id": "test",
@@ -713,18 +653,6 @@
                         },
                         "test.cram.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
-                ],
-                "cram": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.cram:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "duplicate_metrics": [
-                    
                 ],
                 "qc_metrics": [
                     
@@ -740,9 +668,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:34:53.848400581"
+        "timestamp": "2026-03-12T08:49:59.693487969"
     },
     "homo_sapiens - fastq - bam - interval_file - stub": {
         "content": [
@@ -775,28 +703,13 @@
                     
                 ],
                 "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "8": [
+                "6": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
                         "4.6.0-1"
-                    ]
-                ],
-                "bai": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bam": [
@@ -814,14 +727,17 @@
                 "compatible_versions": [
                     "compatible_versions.yml:md5,9752526376a71449ae2f33c4b8b6b19e"
                 ],
-                "crai": [
-                    
-                ],
-                "cram": [
-                    
-                ],
                 "duplicate_metrics": [
                     
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "qc_metrics": [
                     
@@ -837,8 +753,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-01-21T13:31:30.016991953"
+        "timestamp": "2026-03-12T08:47:09.61266936"
     }
 }

--- a/modules/nf-core/parabricks/minimap2/tests/nextflow.config
+++ b/modules/nf-core/parabricks/minimap2/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'PARABRICKS_MINIMAP2' {
+        ext.args = params.module_args
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -204,6 +204,11 @@ profiles {
     }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }
+    gpu {
+        docker.runOptions       = '-u $(id -u):$(id -g) --gpus all'
+        apptainer.runOptions    = '--nv'
+        singularity.runOptions  = '--nv'
+    }
 }
 
 // Load nf-core custom profiles from different Institutions

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,7 @@ params {
     // Mapping
     skip_save_minimap2_index            = false
     kmer_size                           = 14
+    gpu_align                           = false
 
     // Analysis options
     retain_introns                      = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -198,6 +198,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Save the secondary alignments when aligning to the transcriptome"
+                },
+                "gpu_align": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use the Parabricks GPU-accelerated version of minimap2"
                 }
             },
             "fa_icon": "far fa-map"

--- a/nf-test.config
+++ b/nf-test.config
@@ -1,0 +1,30 @@
+config {
+    // location for all nf-test tests
+    testsDir = "."
+
+    // nf-test directory including temporary files for each test
+    workDir = System.getenv("NFT_WORKDIR") ?: ".nf-test"
+
+    // location of an optional nextflow.config file specific for executing tests
+    configFile = "tests/nextflow.config"
+
+    // ignore tests coming from the nf-core/modules repo
+    // Also ignore parabricks tests when respective env vars are set (forks/ARM/CPU-only)
+    def skipParabricks = System.getenv("SKIP_PARABRICKS") == "true"
+
+    def baseIgnore = ['modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*']
+    def parabricksTests = ['tests/parabricks_default.nf.test', 'subworkflows/local/align_longreads.nf/tests/main.parabricks.nf.test']
+
+    ignore = baseIgnore + (skipParabricks ? parabricksTests : [])
+
+    // run all tests with the profile(s) specified by each CI workflow
+
+    // list of filenames or patterns that should be trigger a full test run
+    triggers = ['nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore', 'modules.json']
+
+    // load the necessary plugins
+    plugins {
+        load "nft-bam@0.4.0"
+        load "nft-utils@0.0.5"
+    }
+}

--- a/nf-test.config
+++ b/nf-test.config
@@ -13,7 +13,7 @@ config {
     def skipParabricks = System.getenv("SKIP_PARABRICKS") == "true"
 
     def baseIgnore = ['modules/nf-core/**/tests/*', 'subworkflows/nf-core/**/tests/*']
-    def parabricksTests = ['tests/parabricks_default.nf.test', 'subworkflows/local/align_longreads.nf/tests/main.parabricks.nf.test']
+    def parabricksTests = ['subworkflows/local/align_longreads/align_longreads/tests/main.parabricks.nf.test']
 
     ignore = baseIgnore + (skipParabricks ? parabricksTests : [])
 

--- a/subworkflows/local/align_longreads.nf
+++ b/subworkflows/local/align_longreads.nf
@@ -7,9 +7,10 @@ include { BAM_SORT_STATS_SAMTOOLS                                     } from '..
 include { BAM_SORT_STATS_SAMTOOLS as BAM_SORT_STATS_SAMTOOLS_FILTERED } from '../../subworkflows/nf-core/bam_sort_stats_samtools/main'
 
 // MODULES
-include { MINIMAP2_INDEX                          } from '../../modules/nf-core/minimap2/index'
-include { MINIMAP2_ALIGN                          } from '../../modules/nf-core/minimap2/align'
-include { SAMTOOLS_VIEW as SAMTOOLS_FILTER_MAPPED } from '../../modules/nf-core/samtools/view'
+include { MINIMAP2_INDEX                            } from '../../modules/nf-core/minimap2/index'
+include { MINIMAP2_ALIGN                            } from '../../modules/nf-core/minimap2/align'
+include { PARABRICKS_MINIMAP2 as MINIMAP2_ALIGN_GPU } from '../../modules/nf-core/parabricks/minimap2/main'
+include { SAMTOOLS_VIEW as SAMTOOLS_FILTER_MAPPED   } from '../../modules/nf-core/samtools/view'
 
 include { RSEQC_READDISTRIBUTION } from '../../modules/nf-core/rseqc/readdistribution/main'
 include { NANOCOMP               } from '../../modules/nf-core/nanocomp/main'
@@ -23,6 +24,7 @@ workflow ALIGN_LONGREADS {
         fastq       // channel: [ val(meta), path(fastq) ]
         rseqc_bed   // channel: [ val(meta), path(rseqc_bed) ]
 
+        gpu                      // bool: Run GPU accelerated version of minimap2
         skip_save_minimap2_index // bool: Skip saving the minimap2 index
         skip_qc                  // bool: Skip qc steps
         skip_rseqc               // bool: Skip RSeQC
@@ -42,19 +44,31 @@ workflow ALIGN_LONGREADS {
         }
 
         //
-        // MINIMAP2_ALIGN
+        // MINIMAP2_ALIGN: Supports GPU and CPU
         //
 
-        MINIMAP2_ALIGN (
-            fastq,
-            ch_minimap_ref,
-            true,
-            "bai",
-            "",
-            ""
-        )
+        if (gpu) {
+            MINIMAP2_ALIGN_GPU (
+                fastq,
+                ch_minimap_ref,
+                true,
+                "bai",
+                "",
+                ""
+            )
+            ch_versions = ch_versions.mix(MINIMAP2_ALIGN_GPU.out.versions)
 
-        ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
+        } else {
+            MINIMAP2_ALIGN (
+                fastq,
+                ch_minimap_ref,
+                true,
+                "bai",
+                "",
+                ""
+            )
+            ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
+        }
 
         //
         // SUBWORKFLOW: BAM_SORT_STATS_SAMTOOLS

--- a/subworkflows/local/align_longreads.nf
+++ b/subworkflows/local/align_longreads.nf
@@ -24,7 +24,7 @@ workflow ALIGN_LONGREADS {
         fastq       // channel: [ val(meta), path(fastq) ]
         rseqc_bed   // channel: [ val(meta), path(rseqc_bed) ]
 
-        gpu                      // bool: Run GPU accelerated version of minimap2
+        gpu_align                // bool: Run GPU accelerated version of minimap2
         skip_save_minimap2_index // bool: Skip saving the minimap2 index
         skip_qc                  // bool: Skip qc steps
         skip_rseqc               // bool: Skip RSeQC
@@ -47,7 +47,7 @@ workflow ALIGN_LONGREADS {
         // MINIMAP2_ALIGN: Supports GPU and CPU
         //
 
-        if (gpu) {
+        if (gpu_align) {
             MINIMAP2_ALIGN_GPU (
                 fastq,
                 ch_minimap_ref,

--- a/subworkflows/local/align_longreads.nf
+++ b/subworkflows/local/align_longreads.nf
@@ -50,13 +50,13 @@ workflow ALIGN_LONGREADS {
         if (gpu_align) {
             MINIMAP2_ALIGN_GPU (
                 fastq,
+                fasta,
                 ch_minimap_ref,
-                true,
-                "bai",
-                "",
-                ""
+                [],
+                [],
+                "bam"
             )
-            ch_versions = ch_versions.mix(MINIMAP2_ALIGN_GPU.out.versions)
+            ch_versions = ch_versions.mix(MINIMAP2_ALIGN_GPU.out.compatible_versions)
 
         } else {
             MINIMAP2_ALIGN (

--- a/subworkflows/local/align_longreads/main.nf
+++ b/subworkflows/local/align_longreads/main.nf
@@ -3,18 +3,16 @@
 //
 
 // SUBWORKFLOWS
-include { BAM_SORT_STATS_SAMTOOLS                                     } from '../../subworkflows/nf-core/bam_sort_stats_samtools/main'
-include { BAM_SORT_STATS_SAMTOOLS as BAM_SORT_STATS_SAMTOOLS_FILTERED } from '../../subworkflows/nf-core/bam_sort_stats_samtools/main'
+include { BAM_SORT_STATS_SAMTOOLS                                     } from '../../../subworkflows/nf-core/bam_sort_stats_samtools/main'
+include { BAM_SORT_STATS_SAMTOOLS as BAM_SORT_STATS_SAMTOOLS_FILTERED } from '../../../subworkflows/nf-core/bam_sort_stats_samtools/main'
 
 // MODULES
-include { MINIMAP2_INDEX                            } from '../../modules/nf-core/minimap2/index'
-include { MINIMAP2_ALIGN                            } from '../../modules/nf-core/minimap2/align'
-include { PARABRICKS_MINIMAP2 as MINIMAP2_ALIGN_GPU } from '../../modules/nf-core/parabricks/minimap2/main'
-include { SAMTOOLS_VIEW as SAMTOOLS_FILTER_MAPPED   } from '../../modules/nf-core/samtools/view'
-
-include { RSEQC_READDISTRIBUTION } from '../../modules/nf-core/rseqc/readdistribution/main'
-include { NANOCOMP               } from '../../modules/nf-core/nanocomp/main'
-
+include { MINIMAP2_INDEX                            } from '../../../modules/nf-core/minimap2/index'
+include { MINIMAP2_ALIGN                            } from '../../../modules/nf-core/minimap2/align'
+include { PARABRICKS_MINIMAP2 as MINIMAP2_ALIGN_GPU } from '../../../modules/nf-core/parabricks/minimap2/main'
+include { SAMTOOLS_VIEW as SAMTOOLS_FILTER_MAPPED   } from '../../../modules/nf-core/samtools/view'
+include { RSEQC_READDISTRIBUTION                    } from '../../../modules/nf-core/rseqc/readdistribution/main'
+include { NANOCOMP                                  } from '../../../modules/nf-core/nanocomp/main'
 
 workflow ALIGN_LONGREADS {
     take:
@@ -51,7 +49,7 @@ workflow ALIGN_LONGREADS {
             MINIMAP2_ALIGN_GPU (
                 fastq,
                 fasta,
-                ch_minimap_ref,
+                [],
                 [],
                 [],
                 "bam"

--- a/subworkflows/local/align_longreads/main.nf
+++ b/subworkflows/local/align_longreads/main.nf
@@ -9,7 +9,7 @@ include { BAM_SORT_STATS_SAMTOOLS as BAM_SORT_STATS_SAMTOOLS_FILTERED } from '..
 // MODULES
 include { MINIMAP2_INDEX                            } from '../../../modules/nf-core/minimap2/index'
 include { MINIMAP2_ALIGN                            } from '../../../modules/nf-core/minimap2/align'
-include { PARABRICKS_MINIMAP2 as MINIMAP2_ALIGN_GPU } from '../../../modules/nf-core/parabricks/minimap2/main'
+include { PARABRICKS_MINIMAP2 as MINIMAP2_ALIGN_GPU } from '../../../modules/nf-core/parabricks/minimap2'
 include { SAMTOOLS_VIEW as SAMTOOLS_FILTER_MAPPED   } from '../../../modules/nf-core/samtools/view'
 include { RSEQC_READDISTRIBUTION                    } from '../../../modules/nf-core/rseqc/readdistribution/main'
 include { NANOCOMP                                  } from '../../../modules/nf-core/nanocomp/main'
@@ -45,15 +45,18 @@ workflow ALIGN_LONGREADS {
         // MINIMAP2_ALIGN: Supports GPU and CPU
         //
 
+        ch_bam = channel.empty()
+
         if (gpu_align) {
             MINIMAP2_ALIGN_GPU (
                 fastq,
                 fasta,
-                [],
-                [],
-                [],
+                [ [], [] ], // index
+                [ [], [] ], // interval
+                [ [], [] ], // known_sites
                 "bam"
             )
+            ch_bam = MINIMAP2_ALIGN_GPU.out.bam
             ch_versions = ch_versions.mix(MINIMAP2_ALIGN_GPU.out.compatible_versions)
 
         } else {
@@ -65,13 +68,14 @@ workflow ALIGN_LONGREADS {
                 "",
                 ""
             )
+            ch_bam = MINIMAP2_ALIGN.out.bam
             ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
         }
 
         //
         // SUBWORKFLOW: BAM_SORT_STATS_SAMTOOLS
         // The subworkflow is called in both the minimap2 bams and filtered (mapped only) version
-        BAM_SORT_STATS_SAMTOOLS ( MINIMAP2_ALIGN.out.bam, fasta )
+        BAM_SORT_STATS_SAMTOOLS ( ch_bam, fasta )
         ch_versions = ch_versions.mix(BAM_SORT_STATS_SAMTOOLS.out.versions)
 
         // acquire only mapped reads from bam for downstream processing

--- a/subworkflows/local/align_longreads/tests/main.nf.test
+++ b/subworkflows/local/align_longreads/tests/main.nf.test
@@ -1,0 +1,118 @@
+nextflow_workflow {
+
+    name "Test Subworkflow ALIGN_LONGREADS"
+    script "../main.nf"
+    workflow "ALIGN_LONGREADS"
+    config "./nextflow.config"
+
+    setup {
+        run("SAMTOOLS_FAIDX") {
+            script "../../../../modules/nf-core/samtools/faidx/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                """
+            }
+        }
+    }
+
+    test("align_longreads - default params") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = SAMTOOLS_FAIDX.out.fai
+                input[2] = Channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = Channel.of([
+                    [ id:'test_fastq', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                input[4] = Channel.of([
+                    [ id:'test_bed' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed12', checkIfExists: true)
+                ])
+                input[5] = false  // gpu_align
+                input[6] = true   // skip_save_minimap2_index
+                input[7] = true   // skip_qc
+                input[8] = true   // skip_rseqc
+                input[9] = true   // skip_bam_nanocomp
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    bam(workflow.out.sorted_bam[0][1]).getReadsMD5(),
+                    file(workflow.out.sorted_bai[0][1]).name,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats,
+                    workflow.out.rseqc_read_dist,
+                    workflow.out.nanocomp_bam_html,
+                    workflow.out.nanocomp_bam_txt).match()}
+            )
+        }
+    }
+
+    test("align_longreads - default params - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = SAMTOOLS_FAIDX.fai
+                input[2] = Channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = Channel.of([
+                    [ id:'test_fastq', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                input[4] = Channel.of([
+                    [ id:'test_bed' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed12', checkIfExists: true)
+                ])
+                input[5] = false  // gpu_align
+                input[6] = true   // skip_save_minimap2_index
+                input[7] = true   // skip_qc
+                input[8] = true   // skip_rseqc
+                input[9] = true   // skip_bam_nanocomp
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.sorted_bam,
+                    workflow.out.sorted_bai,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats,
+                    workflow.out.rseqc_read_dist,
+                    workflow.out.nanocomp_bam_html,
+                    workflow.out.nanocomp_bam_txt).match()}
+            )
+        }
+    }
+}

--- a/subworkflows/local/align_longreads/tests/main.nf.test
+++ b/subworkflows/local/align_longreads/tests/main.nf.test
@@ -115,4 +115,100 @@ nextflow_workflow {
             )
         }
     }
+
+    test("align_longreads - gpu params") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = SAMTOOLS_FAIDX.out.fai
+                input[2] = Channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = Channel.of([
+                    [ id:'test_fastq', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                input[4] = Channel.of([
+                    [ id:'test_bed' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed12', checkIfExists: true)
+                ])
+                input[5] = true   // gpu_align
+                input[6] = true   // skip_save_minimap2_index
+                input[7] = true   // skip_qc
+                input[8] = true   // skip_rseqc
+                input[9] = true   // skip_bam_nanocomp
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    bam(workflow.out.sorted_bam[0][1]).getReadsMD5(),
+                    file(workflow.out.sorted_bai[0][1]).name,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats,
+                    workflow.out.rseqc_read_dist,
+                    workflow.out.nanocomp_bam_html,
+                    workflow.out.nanocomp_bam_txt).match()}
+            )
+        }
+    }
+
+    test("align_longreads - gpu params - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[1] = SAMTOOLS_FAIDX.fai
+                input[2] = Channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = Channel.of([
+                    [ id:'test_fastq', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                input[4] = Channel.of([
+                    [ id:'test_bed' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed12', checkIfExists: true)
+                ])
+                input[5] = true   // gpu_align
+                input[6] = true   // skip_save_minimap2_index
+                input[7] = true   // skip_qc
+                input[8] = true   // skip_rseqc
+                input[9] = true   // skip_bam_nanocomp
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.sorted_bam,
+                    workflow.out.sorted_bai,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats,
+                    workflow.out.rseqc_read_dist,
+                    workflow.out.nanocomp_bam_html,
+                    workflow.out.nanocomp_bam_txt).match()}
+            )
+        }
+    }
 }

--- a/subworkflows/local/align_longreads/tests/main.nf.test.snap
+++ b/subworkflows/local/align_longreads/tests/main.nf.test.snap
@@ -1,0 +1,49 @@
+{
+    "align_longreads - default params": {
+        "content": [
+            "1bc714ef98439d5cc71765b647c5cf64",
+            "wacky.bam.bai",
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.stats:md5,6223a2d2ff1c37daf21f849ffd7c49f3"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.flagstat:md5,e9ce9093133116bc54fd335cfe698372"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.idxstats:md5,e16eb632f7f462514b0873c7ac8ac905"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-12T10:52:19.819991098"
+    }
+}

--- a/subworkflows/local/align_longreads/tests/main.nf.test.snap
+++ b/subworkflows/local/align_longreads/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "align_longreads - default params": {
         "content": [
             "1bc714ef98439d5cc71765b647c5cf64",
-            "wacky.bam.bai",
+            "my_test.bam.bai",
             [
                 [
                     {
                         "id": "test_fastq",
                         "single_end": true
                     },
-                    "test_fastq.stats:md5,6223a2d2ff1c37daf21f849ffd7c49f3"
+                    "test_fastq.stats:md5,e5906a3e88cfb0c04ba31055643240ef"
                 ]
             ],
             [
@@ -44,6 +44,53 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-12T10:52:19.819991098"
+        "timestamp": "2026-03-12T12:55:16.764044041"
+    },
+    "align_longreads - gpu params": {
+        "content": [
+            "d41d8cd98f00b204e9800998ecf8427e",
+            "my_test.bam.bai",
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.stats:md5,99111faf8889928367b888173f86a277"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.flagstat:md5,ba966c6410eccf2375c3bcc081ef4787"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_fastq",
+                        "single_end": true
+                    },
+                    "test_fastq.idxstats:md5,7c8e67206e2a55b23091c47122a64218"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-12T13:31:47.369919678"
     }
 }

--- a/subworkflows/local/align_longreads/tests/nextflow.config
+++ b/subworkflows/local/align_longreads/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'SAMTOOLS_SORT.*' {
+        ext.prefix = 'my_test'
+    }
+}

--- a/subworkflows/local/process_longread_scrna.nf
+++ b/subworkflows/local/process_longread_scrna.nf
@@ -32,6 +32,7 @@ workflow PROCESS_LONGREAD_SCRNA {
         genome_aligned  // bool: Whether the bam is aligned to the genome or not
         fasta_delimiter // str: Delimiter character used in sequence id in fasta
 
+        gpu                      // bool: Run GPU accelerated version of minimap2
         skip_save_minimap2_index // bool: Skip saving the minimap2 index
         skip_qc                  // bool: Skip qc steps
         skip_rseqc               // bool: Skip RSeQC
@@ -52,6 +53,7 @@ workflow PROCESS_LONGREAD_SCRNA {
             gtf,
             fastq,
             rseqc_bed,
+            gpu,
             skip_save_minimap2_index,
             skip_qc,
             skip_rseqc,

--- a/subworkflows/local/process_longread_scrna.nf
+++ b/subworkflows/local/process_longread_scrna.nf
@@ -3,7 +3,7 @@
 //
 
 // SUBWORKFLOWS
-include { ALIGN_LONGREADS         } from '../../subworkflows/local/align_longreads'
+include { ALIGN_LONGREADS         } from '../../subworkflows/local/align_longreads/align_longreads'
 include { QUANTIFY_SCRNA_ISOQUANT } from '../../subworkflows/local/quantify_scrna_isoquant'
 include { QUANTIFY_SCRNA_OARFISH  } from '../../subworkflows/local/quantify_scrna_oarfish'
 include { DEDUP_UMIS              } from '../../subworkflows/local/dedup_umis'

--- a/subworkflows/local/process_longread_scrna.nf
+++ b/subworkflows/local/process_longread_scrna.nf
@@ -3,7 +3,7 @@
 //
 
 // SUBWORKFLOWS
-include { ALIGN_LONGREADS         } from '../../subworkflows/local/align_longreads/align_longreads'
+include { ALIGN_LONGREADS         } from '../../subworkflows/local/align_longreads/main'
 include { QUANTIFY_SCRNA_ISOQUANT } from '../../subworkflows/local/quantify_scrna_isoquant'
 include { QUANTIFY_SCRNA_OARFISH  } from '../../subworkflows/local/quantify_scrna_oarfish'
 include { DEDUP_UMIS              } from '../../subworkflows/local/dedup_umis'

--- a/subworkflows/local/process_longread_scrna.nf
+++ b/subworkflows/local/process_longread_scrna.nf
@@ -32,7 +32,7 @@ workflow PROCESS_LONGREAD_SCRNA {
         genome_aligned  // bool: Whether the bam is aligned to the genome or not
         fasta_delimiter // str: Delimiter character used in sequence id in fasta
 
-        gpu                      // bool: Run GPU accelerated version of minimap2
+        gpu_align                // bool: Run GPU accelerated version of minimap2
         skip_save_minimap2_index // bool: Skip saving the minimap2 index
         skip_qc                  // bool: Skip qc steps
         skip_rseqc               // bool: Skip RSeQC
@@ -53,7 +53,7 @@ workflow PROCESS_LONGREAD_SCRNA {
             gtf,
             fastq,
             rseqc_bed,
-            gpu,
+            gpu_align,
             skip_save_minimap2_index,
             skip_qc,
             skip_rseqc,

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -4,7 +4,7 @@
 ========================================================================================
 */
 
-// TODO nf-core: Specify any additional parameters here
+// Specify any additional parameters here
 // Or any resources requirements
 params {
     modules_testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/modules/'

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -1,0 +1,31 @@
+/*
+========================================================================================
+    Nextflow config file for running nf-test tests
+========================================================================================
+*/
+
+// TODO nf-core: Specify any additional parameters here
+// Or any resources requirements
+params {
+    modules_testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/modules/'
+    pipelines_testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/'
+    outdir = 'results'
+}
+
+aws.client.anonymous = true // fixes S3 access issues on self-hosted runners
+
+// Impose sensible resource limits for testing
+process {
+    withName: '.*' {
+        cpus   = 2
+        memory = 3.GB
+        time   = 2.h
+    }
+
+    // Parabricks requires at least 30GB of memory to run, and only one GPU is available
+    withName: '.*:PARABRICKS_MINIMAP2' {
+        memory   = 30.GB
+        maxForks = 1
+    }
+
+}

--- a/workflows/scnanoseq.nf
+++ b/workflows/scnanoseq.nf
@@ -446,6 +446,7 @@ workflow SCNANOSEQ {
             genome_quants,
             params.dedup_tool,
             true, // Used to indicate the bam is genome aligned
+            params.gpu_align
             params.fasta_delimiter,
             params.skip_save_minimap2_index,
             params.skip_qc,
@@ -506,6 +507,7 @@ workflow SCNANOSEQ {
             params.dedup_tool,
             false, // Indicates this is NOT genome aligned
             params.fasta_delimiter,
+            params.gpu_align,
             params.skip_save_minimap2_index,
             params.skip_qc,
             true, // RSeQC does not work well with transcriptome alignments

--- a/workflows/scnanoseq.nf
+++ b/workflows/scnanoseq.nf
@@ -446,7 +446,7 @@ workflow SCNANOSEQ {
             genome_quants,
             params.dedup_tool,
             true, // Used to indicate the bam is genome aligned
-            params.gpu_align
+            params.gpu_align,
             params.fasta_delimiter,
             params.skip_save_minimap2_index,
             params.skip_qc,


### PR DESCRIPTION
This PR adds GPU accelerated Parabricks minimap2 module to the `align_longread` subworkflow in the scnanoseq pipeline. 

It also adds basic nf-tests for this subworkflow. 

<!--
# nf-core/scnanoseq pull request

Many thanks for contributing to nf-core/scnanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [] This comment contains a description of changes (with reason).
- [] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scnanoseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scnanoseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
